### PR TITLE
Add PyVista for 3D plotting in Python

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@ and was created by following people.
 ## Contributors (in order of contributions)
 
 - Falk Heße, Email: <falk.hesse@ufz.de>
+- Bane Sullivan, GitHub: [@banesullivan](https://github.com/banesullivan)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ srf.plot()
 <img src="https://raw.githubusercontent.com/GeoStat-Framework/GSTools/master/docs/source/pics/gau_field.png" alt="Random field" width="600px"/>
 </p>
 
-A similar example but for a three dimensional field is exported to a [VTK](https://vtk.org/) file, which can be visualized with [ParaView](https://www.paraview.org/) or [PyVista](http://docs.pyvista.org) in Python:
+A similar example but for a three dimensional field is exported to a [VTK](https://vtk.org/) file, which can be visualized with [ParaView](https://www.paraview.org/) or [PyVista](https://docs.pyvista.org) in Python:
 
 ```python
 from gstools import SRF, Gaussian

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ srf.plot()
 <img src="https://raw.githubusercontent.com/GeoStat-Framework/GSTools/master/docs/source/pics/gau_field.png" alt="Random field" width="600px"/>
 </p>
 
-A similar example but for a three dimensional field is exported to a [VTK](https://vtk.org/) file, which can be visualized with [ParaView](https://www.paraview.org/).
+A similar example but for a three dimensional field is exported to a [VTK](https://vtk.org/) file, which can be visualized with [ParaView](https://www.paraview.org/) or [PyVista](http://docs.pyvista.org) in Python:
 
 ```python
 from gstools import SRF, Gaussian
@@ -114,7 +114,10 @@ x = y = z = range(100)
 model = Gaussian(dim=3, var=0.6, len_scale=20)
 srf = SRF(model)
 srf((x, y, z), mesh_type='structured')
-srf.vtk_export('3d_field')
+srf.vtk_export('3d_field') # Save to a VTK file for ParaView
+
+mesh = srf.to_pyvista() # Create a PyVista mesh for plotting in Python
+mesh.threshold_percent(0.5).plot()
 ```
 
 <p align="center">
@@ -222,10 +225,11 @@ yielding
 [kraichnan_link]: https://doi.org/10.1063/1.1692799
 
 
-## VTK Export
+## VTK/PyVista Export
 
 After you have created a field, you may want to save it to file, so we provide
-a handy [VTK][vtk_link] export routine:
+a handy [VTK][vtk_link] export routine using the `.vtk_export()` or you could
+create a VTK/PyVista dataset for use in Python with to `.to_pyvista()` method:
 
 ```python
 from gstools import SRF, Gaussian
@@ -233,10 +237,13 @@ x = y = range(100)
 model = Gaussian(dim=2, var=1, len_scale=10)
 srf = SRF(model)
 srf((x, y), mesh_type='structured')
-srf.vtk_export("field")
+srf.vtk_export("field") # Saves to a VTK file
+mesh = srf.to_pyvista() # Create a VTK/PyVista dataset in memory
+mesh.plot()
 ```
 
-Which gives a RectilinearGrid VTK file ``field.vtr``.
+Which gives a RectilinearGrid VTK file ``field.vtr`` or creates a PyVista mesh
+in memory for immediate 3D plotting in Python.
 
 
 ## Requirements:
@@ -245,7 +252,7 @@ Which gives a RectilinearGrid VTK file ``field.vtr``.
 - [SciPy >= 1.1.0](https://www.scipy.org/scipylib)
 - [hankel >= 0.3.6](https://github.com/steven-murray/hankel)
 - [emcee](https://github.com/dfm/emcee)
-- [pyevtk](https://bitbucket.org/pauloh/pyevtk)
+- [pyvista](https://docs.pyvista.org/)
 - [six](https://github.com/benjaminp/six)
 
 

--- a/README.md
+++ b/README.md
@@ -252,8 +252,13 @@ in memory for immediate 3D plotting in Python.
 - [SciPy >= 1.1.0](https://www.scipy.org/scipylib)
 - [hankel >= 0.3.6](https://github.com/steven-murray/hankel)
 - [emcee](https://github.com/dfm/emcee)
-- [pyvista](https://docs.pyvista.org/)
+- [pyevtk](https://bitbucket.org/pauloh/pyevtk)
 - [six](https://github.com/benjaminp/six)
+
+### Optional
+
+- [matplotlib](https://matplotlib.org)
+- [pyvista](https://docs.pyvista.org/)
 
 
 ## Contact

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,5 @@ scipy>=1.1.0
 hankel>=0.3.6
 emcee
 pyevtk
-pyvista
 six
 numpydoc

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,7 +91,8 @@ with a :any:`Gaussian` covariance model.
 
 A similar example but for a three dimensional field is exported to a
 `VTK <https://vtk.org/>`__ file, which can be visualized with
-`ParaView <https://www.paraview.org/>`_.
+`ParaView <https://www.paraview.org/>`_ or
+`PyVista <http://docs.pyvista.org>`__ in Python:
 
 .. code-block:: python
 
@@ -102,7 +103,10 @@ A similar example but for a three dimensional field is exported to a
     model = Gaussian(dim=3, var=0.6, len_scale=20)
     srf = SRF(model)
     srf((x, y, z), mesh_type='structured')
-    srf.vtk_export('3d_field')
+    srf.vtk_export('3d_field') # Save to a VTK file for ParaView
+
+    mesh = srf.to_pyvista() # Create a PyVista mesh for plotting in Python
+    mesh.threshold_percent(0.5).plot()
 
 .. image:: https://raw.githubusercontent.com/GeoStat-Framework/GSTools/master/docs/source/pics/3d_gau_field.png
    :width: 400px
@@ -301,7 +305,7 @@ Requirements
 - `SciPy >= 1.1.0 <http://www.scipy.org>`_
 - `hankel >= 0.3.6 <https://github.com/steven-murray/hankel>`_
 - `emcee <https://github.com/dfm/emcee>`_
-- `pyevtk <https://bitbucket.org/pauloh/pyevtk>`_
+- `pyvista <https://docs.pyvista.org>`_
 - `six <https://github.com/benjaminp/six>`_
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,7 +92,7 @@ with a :any:`Gaussian` covariance model.
 A similar example but for a three dimensional field is exported to a
 `VTK <https://vtk.org/>`__ file, which can be visualized with
 `ParaView <https://www.paraview.org/>`_ or
-`PyVista <http://docs.pyvista.org>`__ in Python:
+`PyVista <https://docs.pyvista.org>`__ in Python:
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -305,8 +305,14 @@ Requirements
 - `SciPy >= 1.1.0 <http://www.scipy.org>`_
 - `hankel >= 0.3.6 <https://github.com/steven-murray/hankel>`_
 - `emcee <https://github.com/dfm/emcee>`_
-- `pyvista <https://docs.pyvista.org>`_
+- `pyevtk <https://bitbucket.org/pauloh/pyevtk>`_
 - `six <https://github.com/benjaminp/six>`_
+
+Optional
+~~~~~~~~
+
+- `matplotlib <https://matplotlib.org>`_
+- `pyvista <https://docs.pyvista.org>`_
 
 
 License

--- a/docs/source/tutorial_01_srf.rst
+++ b/docs/source/tutorial_01_srf.rst
@@ -205,6 +205,13 @@ Using the field from `previous example <Using an Unstructured Grid_>`__, it can 
 
     srf.vtk_export("field")
 
+Or it could visualized immediately in Python using `PyVista <http://docs.pyvista.org>`__:
+
+.. code-block:: python
+
+    mesh = srf.to_pyvista("field")
+    mesh.plot()
+
 The script can be found in :download:`gstools/examples/04_export.py<../../examples/04_export.py>` and
 in :download:`gstools/examples/06_unstr_srf_export.py<../../examples/06_unstr_srf_export.py>`
 

--- a/docs/source/tutorial_01_srf.rst
+++ b/docs/source/tutorial_01_srf.rst
@@ -205,7 +205,7 @@ Using the field from `previous example <Using an Unstructured Grid_>`__, it can 
 
     srf.vtk_export("field")
 
-Or it could visualized immediately in Python using `PyVista <http://docs.pyvista.org>`__:
+Or it could visualized immediately in Python using `PyVista <https://docs.pyvista.org>`__:
 
 .. code-block:: python
 

--- a/examples/06_unstr_srf_export.py
+++ b/examples/06_unstr_srf_export.py
@@ -15,6 +15,8 @@ srf = SRF(model, seed=20170519)
 
 field = srf((x, y))
 srf.vtk_export("field")
+# Or create a PyVista dataset
+# mesh = srf.to_pyvista()
 
 pt.tricontourf(x, y, field.T)
 pt.axes().set_aspect("equal")

--- a/gstools/__init__.py
+++ b/gstools/__init__.py
@@ -81,8 +81,11 @@ Routines to export fields to the vtk format
 .. currentmodule:: gstools.tools
 
 .. autosummary::
+   to_vtk
    vtk_export
+   to_vtk_structured
    vtk_export_structured
+   to_vtk_unstructured
    vtk_export_unstructured
 
 variogram estimation
@@ -149,7 +152,10 @@ __all__ += ["vario_estimate_structured", "vario_estimate_unstructured"]
 
 __all__ += [
     "SRF",
+    "to_vtk_structured",
     "vtk_export_structured",
+    "to_vtk_unstructured",
     "vtk_export_unstructured",
+    "to_vtk",
     "vtk_export",
 ]

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -17,7 +17,7 @@ from functools import partial
 import numpy as np
 
 from gstools.covmodel.base import CovModel
-from gstools.tools.export import vtk_export as vtk_ex
+from gstools.tools.export import to_vtk, vtk_export
 from gstools.field.tools import _get_select
 
 __all__ = ["Field"]
@@ -147,16 +147,15 @@ class Field(object):
                 mesh.point_data[name] = field
         return out
 
-    def vtk_export(
-        self, filename, field_select="field", fieldname="field"
+    def _to_vtk_helper(
+        self, filename=None, field_select="field", fieldname="field"
     ):  # pragma: no cover
-        """Export the stored field to vtk.
+        """Create a VTK/PyVista grid of the stored field.
+
+        This is an internal helper that will handle saving or creating objects
 
         Parameters
         ----------
-        filename : :class:`str`
-            Filename of the file to be saved, including the path. Note that an
-            ending (.vtr or .vtu) will be added to the name.
         field_select : :class:`str`, optional
             Field that should be stored. Can be:
             "field", "raw_field", "krige_field", "err_field" or "krige_var".
@@ -181,7 +180,10 @@ class Field(object):
                 fields = {}
                 for i in range(self.model.dim):
                     fields[fieldname + suf[i]] = field[i]
-                vtk_ex(filename, self.pos, fields, self.mesh_type)
+                if filename is None:
+                    return to_vtk(self.pos, fields, self.mesh_type)
+                else:
+                    return vtk_export(filename, self.pos, fields, self.mesh_type)
         elif self.value_type == "scalar":
             if hasattr(self, field_select):
                 field = getattr(self, field_select)
@@ -190,17 +192,62 @@ class Field(object):
             if not (
                 self.pos is None or field is None or self.mesh_type is None
             ):
-                vtk_ex(filename, self.pos, {fieldname: field}, self.mesh_type)
+                if filename is None:
+                    return to_vtk(self.pos, {fieldname: field}, self.mesh_type)
+                else:
+                    return vtk_export(filename, self.pos, {fieldname: field}, self.mesh_type)
             else:
                 print(
-                    "Field.vtk_export: No "
-                    + field_select
-                    + " stored in the class."
+                    "Field.to_vtk: No " + field_select + " stored in the class."
                 )
         else:
             raise ValueError(
                 "Unknown field value type: {}".format(self.value_type)
             )
+
+
+    def to_pyvista(
+        self, field_select="field", fieldname="field"
+    ):  # pragma: no cover
+        """Create a VTK/PyVista grid of the stored field.
+
+        Parameters
+        ----------
+        field_select : :class:`str`, optional
+            Field that should be stored. Can be:
+            "field", "raw_field", "krige_field", "err_field" or "krige_var".
+            Default: "field"
+        fieldname : :class:`str`, optional
+            Name of the field in the VTK file. Default: "field"
+        """
+        grid = self._to_vtk_helper(filename=None, field_select=field_select,
+                                   fieldname=fieldname)
+        return grid
+
+
+    def vtk_export(
+        self, filename, field_select="field", fieldname="field"
+    ):  # pragma: no cover
+        """Export the stored field to vtk.
+
+        Parameters
+        ----------
+        filename : :class:`str`
+            Filename of the file to be saved, including the path. Note that an
+            ending (.vtr or .vtu) will be added to the name.
+        field_select : :class:`str`, optional
+            Field that should be stored. Can be:
+            "field", "raw_field", "krige_field", "err_field" or "krige_var".
+            Default: "field"
+        fieldname : :class:`str`, optional
+            Name of the field in the VTK file. Default: "field"
+        """
+        if not isinstance(filename, str):
+            raise TypeError("Please use a string filename.")
+        return self._to_vtk_helper(filename=filename,
+                                   field_select=field_select,
+                                   fieldname=fieldname)
+
 
     def plot(self, field="field", fig=None, ax=None):  # pragma: no cover
         """

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -150,12 +150,17 @@ class Field(object):
     def _to_vtk_helper(
         self, filename=None, field_select="field", fieldname="field"
     ):  # pragma: no cover
-        """Create a VTK/PyVista grid of the stored field.
+        """Create a VTK/PyVista grid of the stored field or save a VTK dataset
+        to a file.
 
         This is an internal helper that will handle saving or creating objects
 
         Parameters
         ----------
+        filename : :class:`str`
+            Filename of the file to be saved, including the path. Note that an
+            ending (.vtr or .vtu) will be added to the name. If ``None`` is
+            passed, a PyVista dataset of the appropriate type will be returned.
         field_select : :class:`str`, optional
             Field that should be stored. Can be:
             "field", "raw_field", "krige_field", "err_field" or "krige_var".

--- a/gstools/tools/__init__.py
+++ b/gstools/tools/__init__.py
@@ -8,7 +8,6 @@ Export
 ^^^^^^
 
 .. autosummary::
-   save_vtk_grid
    to_vtk_structured
    vtk_export_structured
    to_vtk_unstructured

--- a/gstools/tools/__init__.py
+++ b/gstools/tools/__init__.py
@@ -8,9 +8,13 @@ Export
 ^^^^^^
 
 .. autosummary::
-   vtk_export
+   save_vtk_grid
+   to_vtk_structured
    vtk_export_structured
+   to_vtk_unstructured
    vtk_export_unstructured
+   to_vtk
+   vtk_export
 
 Special functions
 ^^^^^^^^^^^^^^^^^

--- a/gstools/tools/export.py
+++ b/gstools/tools/export.py
@@ -72,6 +72,12 @@ def to_vtk_structured(pos, fields):  # pragma: no cover
         Structured fields to be saved.
         Either a single numpy array as returned by SRF,
         or a dictionary of fields with theirs names as keys.
+
+    Returns
+    -------
+    pyvista.RectilinearGrid
+        A PyVista rectilinear grid of the structured field data. Data arrays
+        live on the point data of this PyVista dataset.
     """
     x, y, z, fields = _vtk_structured_helper(pos=pos, fields=fields)
     try:
@@ -137,6 +143,13 @@ def to_vtk_unstructured(pos, fields):  # pragma: no cover
         Unstructured fields to be saved.
         Either a single numpy array as returned by SRF,
         or a dictionary of fields with theirs names as keys.
+
+    Returns
+    -------
+    pyvista.UnstructuredGrid
+        A PyVista unstructured grid of the unstructured field data. Data arrays
+        live on the point data of this PyVista dataset. This is essentially
+        a point cloud with no topology.
     """
     x, y, z, fields = _vtk_unstructured_helper(pos=pos, fields=fields)
     try:
@@ -183,6 +196,14 @@ def to_vtk(pos, fields, mesh_type="unstructured"):  # pragma: no cover
         or a dictionary of fields with theirs names as keys.
     mesh_type : :class:`str`, optional
         'structured' / 'unstructured'. Default: structured
+
+    Returns
+    -------
+    pyvista.Common
+        This will return a PyVista object for the given field data in its
+        appropriate type. Structured meshes will return a
+        :class:`pyvista.RectilinearGrid` and unstructured meshes will return
+        an :class:`pyvista.UnstructuredGrid` object.
     """
     if mesh_type == "structured":
         grid = to_vtk_structured(pos=pos, fields=fields)

--- a/gstools/tools/export.py
+++ b/gstools/tools/export.py
@@ -7,8 +7,11 @@ GStools subpackage providing export routines.
 The following functions are provided
 
 .. autosummary::
+   to_vtk_structured
    vtk_export_structured
+   to_vtk_unstructured
    vtk_export_unstructured
+   to_vtk
    vtk_export
 """
 # pylint: disable=C0103, E1101
@@ -16,12 +19,68 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 from pyevtk.hl import gridToVTK, pointsToVTK
+
 from gstools.tools.geometric import pos2xyz
 
-__all__ = ["vtk_export_structured", "vtk_export_unstructured", "vtk_export"]
+try:
+    import pyvista as pv
+except ImportError:
+    pv = None
+
+__all__ = ["to_vtk_structured",
+           "vtk_export_structured",
+           "to_vtk_unstructured",
+           "vtk_export_unstructured",
+           "to_vtk",
+           "vtk_export"]
 
 
 # export routines #############################################################
+
+
+def _vtk_structured_helper(pos, fields):
+    """An internal helper to extract what is needed for the vtk rectilinear grid
+    """
+    if not isinstance(fields, dict):
+        fields = {"field": fields}
+    x, y, z = pos2xyz(pos)
+    if y is None:
+        y = np.array([0])
+    if z is None:
+        z = np.array([0])
+    # need fortran order in VTK
+    for field in fields:
+        fields[field] = fields[field].reshape(-1, order="F")
+        if len(fields[field]) != len(x) * len(y) * len(z):
+            raise ValueError(
+                "gstools.vtk_export_structured: "
+                "field shape doesn't match the given mesh"
+            )
+    return x, y, z, fields
+
+
+
+def to_vtk_structured(pos, fields):  # pragma: no cover
+    """Create a vtk structured rectilinear grid from a field.
+
+    Parameters
+    ----------
+    pos : :class:`list`
+        the position tuple, containing main direction and transversal
+        directions
+    fields : :class:`dict` or :class:`numpy.ndarray`
+        Structured fields to be saved.
+        Either a single numpy array as returned by SRF,
+        or a dictionary of fields with theirs names as keys.
+    """
+    x, y, z, fields = _vtk_structured_helper(pos=pos, fields=fields)
+    try:
+        import pyvista as pv
+        grid = pv.RectilinearGrid(x, y, z)
+        grid.point_arrays.update(fields)
+    except ImportError:
+        raise ImportError("Please install PyVista to create VTK datasets.")
+    return grid
 
 
 def vtk_export_structured(filename, pos, fields):  # pragma: no cover
@@ -40,40 +99,11 @@ def vtk_export_structured(filename, pos, fields):  # pragma: no cover
         Either a single numpy array as returned by SRF,
         or a dictionary of fields with theirs names as keys.
     """
-    if not isinstance(fields, dict):
-        fields = {"field": fields}
-    x, y, z = pos2xyz(pos)
-    if y is None:
-        y = np.array([0])
-    if z is None:
-        z = np.array([0])
-    # need fortran order in VTK
-    for field in fields:
-        fields[field] = fields[field].reshape(-1, order="F")
-        if len(fields[field]) != len(x) * len(y) * len(z):
-            raise ValueError(
-                "gstools.vtk_export_structured: "
-                + "field shape doesn't match the given mesh"
-            )
-    gridToVTK(filename, x, y, z, pointData=fields)
+    x, y, z, fields = _vtk_structured_helper(pos=pos, fields=fields)
+    return gridToVTK(filename, x, y, z, pointData=fields)
 
 
-def vtk_export_unstructured(filename, pos, fields):  # pragma: no cover
-    """Export a field to vtk structured rectilinear grid file.
-
-    Parameters
-    ----------
-    filename : :class:`str`
-        Filename of the file to be saved, including the path. Note that an
-        ending (.vtu) will be added to the name.
-    pos : :class:`list`
-        the position tuple, containing main direction and transversal
-        directions
-    fields : :class:`dict` or :class:`numpy.ndarray`
-        Unstructured fields to be saved.
-        Either a single numpy array as returned by SRF,
-        or a dictionary of fields with theirs names as keys.
-    """
+def _vtk_unstructured_helper(pos, fields):
     if not isinstance(fields, dict):
         fields = {"field": fields}
     x, y, z = pos2xyz(pos)
@@ -90,9 +120,75 @@ def vtk_export_unstructured(filename, pos, fields):  # pragma: no cover
         ):
             raise ValueError(
                 "gstools.vtk_export_unstructured: "
-                + "field shape doesn't match the given mesh"
+                "field shape doesn't match the given mesh"
             )
-    pointsToVTK(filename, x, y, z, data=fields)
+    return x, y, z, fields
+
+
+def to_vtk_unstructured(pos, fields):  # pragma: no cover
+    """Export a field to vtk structured rectilinear grid file.
+
+    Parameters
+    ----------
+    pos : :class:`list`
+        the position tuple, containing main direction and transversal
+        directions
+    fields : :class:`dict` or :class:`numpy.ndarray`
+        Unstructured fields to be saved.
+        Either a single numpy array as returned by SRF,
+        or a dictionary of fields with theirs names as keys.
+    """
+    x, y, z, fields = _vtk_unstructured_helper(pos=pos, fields=fields)
+    try:
+        import pyvista as pv
+        grid = pv.PolyData(np.c_[x, y, z]).cast_to_unstructured_grid()
+        grid.point_arrays.update(fields)
+    except ImportError:
+        raise ImportError("Please install PyVista to create VTK datasets.")
+    return grid
+
+
+def vtk_export_unstructured(filename, pos, fields):  # pragma: no cover
+    """Export a field to vtk unstructured grid file.
+
+    Parameters
+    ----------
+    filename : :class:`str`
+        Filename of the file to be saved, including the path. Note that an
+        ending (.vtu) will be added to the name.
+    pos : :class:`list`
+        the position tuple, containing main direction and transversal
+        directions
+    fields : :class:`dict` or :class:`numpy.ndarray`
+        Unstructured fields to be saved.
+        Either a single numpy array as returned by SRF,
+        or a dictionary of fields with theirs names as keys.
+    """
+    x, y, z, fields = _vtk_unstructured_helper(pos=pos, fields=fields)
+    return pointsToVTK(filename, x, y, z, data=fields)
+
+
+
+def to_vtk(pos, fields, mesh_type="unstructured"):  # pragma: no cover
+    """Create a VTK/PyVista grid.
+
+    Parameters
+    ----------
+    pos : :class:`list`
+        the position tuple, containing main direction and transversal
+        directions
+    fields : :class:`dict` or :class:`numpy.ndarray`
+        [Un]structured fields to be saved.
+        Either a single numpy array as returned by SRF,
+        or a dictionary of fields with theirs names as keys.
+    mesh_type : :class:`str`, optional
+        'structured' / 'unstructured'. Default: structured
+    """
+    if mesh_type == "structured":
+        grid = to_vtk_structured(pos=pos, fields=fields)
+    else:
+        grid = to_vtk_unstructured(pos=pos, fields=fields)
+    return grid
 
 
 def vtk_export(
@@ -116,6 +212,6 @@ def vtk_export(
         'structured' / 'unstructured'. Default: structured
     """
     if mesh_type == "structured":
-        vtk_export_structured(filename=filename, pos=pos, fields=fields)
+        return vtk_export_structured(filename=filename, pos=pos, fields=fields)
     else:
-        vtk_export_unstructured(filename=filename, pos=pos, fields=fields)
+        return vtk_export_unstructured(filename=filename, pos=pos, fields=fields)

--- a/gstools/tools/export.py
+++ b/gstools/tools/export.py
@@ -75,7 +75,7 @@ def to_vtk_structured(pos, fields):  # pragma: no cover
 
     Returns
     -------
-    pyvista.RectilinearGrid
+    :class:`pyvista.RectilinearGrid`
         A PyVista rectilinear grid of the structured field data. Data arrays
         live on the point data of this PyVista dataset.
     """
@@ -146,7 +146,7 @@ def to_vtk_unstructured(pos, fields):  # pragma: no cover
 
     Returns
     -------
-    pyvista.UnstructuredGrid
+    :class:`pyvista.UnstructuredGrid`
         A PyVista unstructured grid of the unstructured field data. Data arrays
         live on the point data of this PyVista dataset. This is essentially
         a point cloud with no topology.
@@ -199,7 +199,7 @@ def to_vtk(pos, fields, mesh_type="unstructured"):  # pragma: no cover
 
     Returns
     -------
-    pyvista.Common
+    :class:`pyvista.RectilinearGrid` or :class:`pyvista.UnstructuredGrid`
         This will return a PyVista object for the given field data in its
         appropriate type. Structured meshes will return a
         :class:`pyvista.RectilinearGrid` and unstructured meshes will return

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ hankel>=0.3.6
 emcee
 pyevtk
 six
-pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,5 @@ scipy>=1.1.0
 hankel>=0.3.6
 emcee
 pyevtk
-pyvista
 six
-matplotlib
 pytest
-pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-#required for readthedocs.org
-cython>=0.28.3
 numpy>=1.14.5
 scipy>=1.1.0
 hankel>=0.3.6
@@ -7,4 +5,6 @@ emcee
 pyevtk
 pyvista
 six
-numpydoc
+matplotlib
+pytest
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -277,6 +277,9 @@ setup(
         "pyevtk",
         "six",
     ],
+    extras_require={
+        "plotting": ["pyvista", "matplotlib"],
+    },
     packages=find_packages(exclude=["tests*", "docs*"]),
     ext_modules=EXT_MODULES,
     include_dirs=[numpy.get_include()],

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,63 @@
+"""Test the PyVista/VTK export methods
+"""
+import unittest
+import numpy as np
+import os
+import tempfile
+import shutil
+
+from gstools import SRF, Gaussian, Exponential
+from gstools.random import MasterRNG
+
+HAS_PYVISTA = False
+try:
+    import pyvista as pv
+    HAS_PYVISTA = True
+except ImportError:
+    pass
+
+
+class TestKrige(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        # structured field with a size 100x100x100 and a grid-size of 1x1x1
+        x = y = z = range(100)
+        model = Gaussian(dim=3, var=0.6, len_scale=20)
+        self.srf_structured = SRF(model)
+        self.srf_structured((x, y, z), mesh_type='structured')
+        # unstrucutred field
+        seed = MasterRNG(19970221)
+        rng = np.random.RandomState(seed())
+        x = rng.randint(0, 100, size=10000)
+        y = rng.randint(0, 100, size=10000)
+        model = Exponential(dim=2, var=1, len_scale=[12., 3.], angles=np.pi/8.)
+        self.srf_unstructured = SRF(model, seed=20170519)
+        self.srf_unstructured([x, y])
+
+
+    def tearDown(self):
+        # Remove the test data directory after the test
+        shutil.rmtree(self.test_dir)
+
+
+    @unittest.skipIf(not HAS_PYVISTA, "PyVista is not installed.")
+    def test_pyvista(self):
+        mesh = self.srf_structured.to_pyvista()
+        self.assertIsInstance(mesh, pv.RectilinearGrid)
+        mesh = self.srf_unstructured.to_pyvista()
+        self.assertIsInstance(mesh, pv.UnstructuredGrid)
+
+
+    def test_pyevtk_export(self):
+        # Structured
+        sfilename = os.path.join(self.test_dir, "structured")
+        self.srf_structured.vtk_export(sfilename)
+        self.assertTrue(os.path.isfile(sfilename + ".vtr"))
+        # Unstructured
+        ufilename = os.path.join(self.test_dir, "unstructured")
+        self.srf_unstructured.vtk_export(ufilename)
+        self.assertTrue(os.path.isfile(ufilename + ".vtu"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Todo

- [x] Make PyVista an optional dependency
- [x] Address #30 before merging. 

-----

This PR uses [PyVista](http://docs.pyvista.org) for creating VTK datasets in Python for immediate plotting. The `pyevtk`  export code is still present to allow users to save VTK files in any Python environment. PyVista is a heavy dependency so these additions are implemented as optional features.

When complete, this will need to use "Squash and Merge"

-----

PyVista allows you to create VTK data objects in memory really easily instead of saving them out to static files. *Why might you want VTK/PyVista meshes in Python?* So you can skip saving VTK files and visualize the datasets right in Python! Check out this example:

```py
import pyvista as pv
from gstools import SRF, Gaussian
import matplotlib.pyplot as pt

# structured field with a size 100x100x100 and a grid-size of 1x1x1
x = y = z = range(100)
model = Gaussian(dim=3, var=0.6, len_scale=20)
srf = SRF(model)
srf((x, y, z), mesh_type='structured')

# Create the VTK mesh
mesh = srf.to_pyvista()

# Quickly plot in 3D:
mesh.plot()
```

![download](https://user-images.githubusercontent.com/22067021/65274009-a1e1c200-dadf-11e9-8744-5694c96b1526.png)

```py
# Use PyVista for some interactive plotting
p = pv.Plotter(notebook=False)
p.add_mesh_threshold(mesh)
p.show_grid()
p.show()
```
![2019-09-19 13 10 31](https://user-images.githubusercontent.com/22067021/65274017-a60ddf80-dadf-11e9-9fe2-a27e1197c4a2.gif)



### Notes

I added a new method: `to_pyvista()`.