### PR TITLE
Print deprecation warnings for Python 2.7 and 3.4

### DIFF
--- a/gstools/__init__.py
+++ b/gstools/__init__.py
@@ -101,6 +101,8 @@ Estimate the variogram of a given field
 
 from __future__ import absolute_import
 
+import sys
+
 from gstools._version import __version__
 from gstools import field, variogram, random, covmodel, tools, krige, transform
 from gstools.field import SRF
@@ -128,6 +130,21 @@ from gstools.covmodel import (
     TPLExponential,
     TPLStable,
 )
+
+
+PY_VERSION = sys.version_info
+DEPRECATION_STR = (
+    "DEPRECATION: Python {0} will reach the end of is life on "
+    "{1}. Please upgrade your Python as Python {0} "
+    "won't be maintained after that date. A future version of GSTools will "
+    "drop support for Python {0}."
+)
+
+if PY_VERSION[:2] == (2, 7):
+    print(DEPRECATION_STR.format(2.7, "1st January 2020"))
+elif PY_VERSION[:2] == (3, 4):
+    print(DEPRECATION_STR.format(3.4, "18th March 2019"))
+
 
 __all__ = ["__version__"]
 __all__ += ["covmodel", "field", "variogram", "krige", "random", "tools"]


### PR DESCRIPTION
Maybe this is coming a bit late, but we should soon make a new release with the deprecation warnings of this pull request and give our users a head start with upgrading their Python versions.

For the discussion about dropping the support, see issue #40.