### PR TITLE
CovModel: check optional arguments and warn if unknown

### DIFF
--- a/docs/source/tutorial_02_cov.rst
+++ b/docs/source/tutorial_02_cov.rst
@@ -371,7 +371,10 @@ This leads to the so called **stable** covariance model and we can define it by
 
 As you can see, we override the method :any:`CovModel.default_opt_arg` to provide
 a standard value for the optional argument ``alpha`` and we can access it
-in the correlation function by ``self.alpha``
+in the correlation function by ``self.alpha``.
+
+We strongly encourage to define a standard value this way. Otherwise a
+warning will occure when creating the model.
 
 Now we can instantiate this model:
 

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -11,6 +11,7 @@ The following classes are provided
 """
 # pylint: disable=C0103, R0201
 
+import warnings
 import numpy as np
 from scipy.integrate import quad as integral
 from scipy.optimize import curve_fit, root
@@ -35,6 +36,11 @@ HANKEL_DEFAULT = {
     "N": 1000,
     "h": 0.001,
 }
+
+
+class AttributeWarning(UserWarning):
+    pass
+
 
 # The CovModel Base-Class #####################################################
 
@@ -134,6 +140,13 @@ class CovModel(metaclass=InitSubclassMeta):
                     + opt_name
                     + "' has a 'bad' name, since it is already present in "
                     + "the class. It could not be added to the model"
+                )
+            if opt_name not in self.default_opt_arg().keys():
+                warnings.warn(
+                    "The given optional argument '{}' ".format(opt_name)
+                    + "is unknown or has at least no defined standard value. "
+                    + "Or you made a Typo... hehe.",
+                    AttributeWarning,
                 )
             # Magic happens here
             setattr(self, opt_name, opt_arg[opt_name])


### PR DESCRIPTION
At the moment there was no warning if a user set an additional parameter while creating a covariance model.
This can be fatal if:
- a model needs an additional parameter, but there is no default value and no value was given with instantiation
- a user had a typo in the standard parameters (See #45)

This PR adds a warning, when an optional parameter was given, that has no predefined default value. Also the documentation was updated accordingly.