### PR TITLE
Update cython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to **GSTools** will be documented in this file.
 ## [Unreleased]
 
 ### Enhancements
+- different variogram estimator functions can now be used #51
 
 ### Changes
 - Python versions 2.7 and 3.4 are no longer supported #40 #43
 
 ### Bugfixes
+- a race condition in the structured variogram estimation has been fixed #51
 
 
 ## [1.1.1] - Reverberating Red - 2019-11-08

--- a/README.md
+++ b/README.md
@@ -49,22 +49,8 @@ running. Install the package by typing the following command in a command termin
 
     pip install gstools
 
-To get the latest development version you can install it directly from GitHub:
-
-    pip install https://github.com/GeoStat-Framework/GSTools/archive/develop.zip
-
-To enable the OpenMP support, you have to provide a C compiler, Cython and OpenMP.
-To get all other dependencies, it is recommended to first install gstools once
-in the standard way just decribed.
-Then use the following command:
-
-    pip install --global-option="--openmp" gstools
-
-Or for the development version:
-
-    pip install --global-option="--openmp" https://github.com/GeoStat-Framework/GSTools/archive/develop.zip
-
-If something went wrong during installation, try the [``-I`` flag from pip][pipiflag].
+To install the latest development version via pip, see the
+[documentation][doc_install_link].
 
 
 ## Citation
@@ -336,6 +322,7 @@ You can contact us via <info@geostat-framework.org>.
 [cov_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/latest/covmodel.base.html#gstools.covmodel.base.CovModel
 [stable_link]: https://en.wikipedia.org/wiki/Stable_distribution
 [doc_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/latest/
+[doc_install_link]: https://gstools.readthedocs.io/en/stable/#pip
 [tut_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/latest/tutorials.html
 [tut1_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/latest/tutorial_01_srf.html
 [tut2_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/latest/tutorial_02_cov.html

--- a/gstools/field/summator.pyx
+++ b/gstools/field/summator.pyx
@@ -17,10 +17,10 @@ ctypedef np.double_t DTYPE_t
 
 
 def summate_unstruct(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:,:] pos
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:,:] pos
     ):
     cdef int i, j, d, X_len, N
     cdef double phase
@@ -42,12 +42,12 @@ def summate_unstruct(
     return np.asarray(summed_modes)
 
 def summate_struct(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:] x,
-    double[:] y=None,
-    double[:] z=None,
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:] x,
+    const double[:] y=None,
+    const double[:] z=None,
 ):
     if y == None and z == None:
         return summate_struct_1d(cov_samples, z_1, z_2, x)
@@ -57,10 +57,10 @@ def summate_struct(
         return summate_struct_3d(cov_samples, z_1, z_2, x, y, z)
 
 def summate_struct_1d(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:] x,
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:] x,
     ):
 
     cdef int i, j, X_len, N
@@ -79,11 +79,11 @@ def summate_struct_1d(
     return np.asarray(summed_modes)
 
 def summate_struct_2d(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:] x,
-    double[:] y,
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:] x,
+    const double[:] y,
     ):
     cdef int i, j, k, X_len, Y_len, N
     cdef double phase
@@ -103,12 +103,12 @@ def summate_struct_2d(
     return np.asarray(summed_modes)
 
 def summate_struct_3d(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:] x,
-    double[:] y,
-    double[:] z,
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
     ):
     cdef int i, j, k, l, X_len, Y_len, Z_len, N
     cdef double phase
@@ -133,7 +133,7 @@ def summate_struct_3d(
 
     return np.asarray(summed_modes)
 
-cdef (double) abs_square(double[:] vec) nogil:
+cdef (double) abs_square(const double[:] vec) nogil:
     cdef int i
     cdef double r = 0.
 
@@ -143,10 +143,10 @@ cdef (double) abs_square(double[:] vec) nogil:
     return r
 
 def summate_incompr_unstruct(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:,:] pos
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:,:] pos
     ):
     cdef int i, j, d, X_len, N
     cdef double phase
@@ -176,12 +176,12 @@ def summate_incompr_unstruct(
     return np.asarray(summed_modes)
 
 def summate_incompr_struct(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:] x,
-    double[:] y=None,
-    double[:] z=None,
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:] x,
+    const double[:] y=None,
+    const double[:] z=None,
 ):
     if z == None:
         return summate_incompr_struct_2d(cov_samples, z_1, z_2, x, y)
@@ -189,11 +189,11 @@ def summate_incompr_struct(
         return summate_incompr_struct_3d(cov_samples, z_1, z_2, x, y, z)
 
 def summate_incompr_struct_2d(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:] x,
-    double[:] y,
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:] x,
+    const double[:] y,
     ):
     cdef int i, j, k, d, X_len, Y_len, N
     cdef double phase
@@ -222,12 +222,12 @@ def summate_incompr_struct_2d(
     return np.asarray(summed_modes)
 
 def summate_incompr_struct_3d(
-    double[:,:] cov_samples,
-    double[:] z_1,
-    double[:] z_2,
-    double[:] x,
-    double[:] y,
-    double[:] z,
+    const double[:,:] cov_samples,
+    const double[:] z_1,
+    const double[:] z_2,
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
     ):
     cdef int i, j, k, l, d, X_len, Y_len, Z_len, N
     cdef double phase

--- a/gstools/field/summator.pyx
+++ b/gstools/field/summator.pyx
@@ -1,10 +1,8 @@
-#!python
-#cython: language_level=2
+#cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # -*- coding: utf-8 -*-
 """
 This is the variogram estimater, implemented in cython.
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 
@@ -18,9 +16,6 @@ DTYPE = np.double
 ctypedef np.double_t DTYPE_t
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_unstruct(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -46,9 +41,6 @@ def summate_unstruct(
 
     return np.asarray(summed_modes)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_struct(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -64,9 +56,6 @@ def summate_struct(
     else:
         return summate_struct_3d(cov_samples, z_1, z_2, x, y, z)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_struct_1d(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -89,9 +78,6 @@ def summate_struct_1d(
 
     return np.asarray(summed_modes)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_struct_2d(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -116,9 +102,6 @@ def summate_struct_2d(
 
     return np.asarray(summed_modes)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_struct_3d(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -150,9 +133,6 @@ def summate_struct_3d(
 
     return np.asarray(summed_modes)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 cdef (double) abs_square(double[:] vec) nogil:
     cdef int i
     cdef double r = 0.
@@ -162,9 +142,6 @@ cdef (double) abs_square(double[:] vec) nogil:
 
     return r
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_incompr_unstruct(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -198,9 +175,6 @@ def summate_incompr_unstruct(
 
     return np.asarray(summed_modes)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_incompr_struct(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -214,9 +188,6 @@ def summate_incompr_struct(
     else:
         return summate_incompr_struct_3d(cov_samples, z_1, z_2, x, y, z)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_incompr_struct_2d(
     double[:,:] cov_samples,
     double[:] z_1,
@@ -250,9 +221,6 @@ def summate_incompr_struct_2d(
 
     return np.asarray(summed_modes)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def summate_incompr_struct_3d(
     double[:,:] cov_samples,
     double[:] z_1,

--- a/gstools/krige/krigesum.pyx
+++ b/gstools/krige/krigesum.pyx
@@ -1,9 +1,8 @@
-# cython: language_level=2
+#cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # -*- coding: utf-8 -*-
 """
 This is a summator for the kriging routines
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 
@@ -12,8 +11,6 @@ from cython.parallel import prange
 cimport numpy as np
 
 
-@cython.boundscheck(False) # turn off bounds-checking for entire function
-@cython.wraparound(False)  # turn off negative index wrapping for entire function
 def krigesum(double[:,:] krig_mat, double[:,:] krig_vecs, double[:] cond):
 
     cdef int mat_i = krig_mat.shape[0]

--- a/gstools/krige/krigesum.pyx
+++ b/gstools/krige/krigesum.pyx
@@ -11,7 +11,11 @@ from cython.parallel import prange
 cimport numpy as np
 
 
-def krigesum(double[:,:] krig_mat, double[:,:] krig_vecs, double[:] cond):
+def krigesum(
+    const double[:,:] krig_mat,
+    const double[:,:] krig_vecs,
+    const double[:] cond
+):
 
     cdef int mat_i = krig_mat.shape[0]
     cdef int res_i = krig_vecs.shape[1]

--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -1,12 +1,8 @@
-#!python
-# cython: language_level=2
+#cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # -*- coding: utf-8 -*-
 """
 This is the variogram estimater, implemented in cython.
 """
-#!python
-#cython: language_level=2
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 
@@ -20,23 +16,14 @@ DTYPE = np.double
 ctypedef np.double_t DTYPE_t
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 cdef inline double _distance_1d(double[:] x, double[:] y, double[:] z,
                                int i, int j) nogil:
     return sqrt((x[i] - x[j]) * (x[i] - x[j]))
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 cdef inline double _distance_2d(double[:] x, double[:] y, double[:] z,
                                int i, int j) nogil:
     return sqrt((x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]))
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 cdef inline double _distance_3d(double[:] x, double[:] y, double[:] z,
                                int i, int j) nogil:
     return sqrt((x[i] - x[j]) * (x[i] - x[j]) +
@@ -46,9 +33,6 @@ cdef inline double _distance_3d(double[:] x, double[:] y, double[:] z,
 ctypedef double (*_dist_func)(double[:], double[:], double[:], int, int) nogil
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def unstructured(double[:] f, double[:] bin_edges, double[:] x,
                  double[:] y=None, double[:] z=None):
     if x.shape[0] != f.shape[0]:
@@ -58,19 +42,19 @@ def unstructured(double[:] f, double[:] bin_edges, double[:] x,
         raise ValueError('len(bin_edges) too small')
 
     cdef _dist_func distance
-    #3d
+    # 3d
     if z is not None:
         if z.shape[0] != f.shape[0]:
             raise ValueError('len(z) = {0} != len(f) = {1} '.
                              format(z.shape[0], f.shape[0]))
         distance = _distance_3d
-    #2d
+    # 2d
     elif y is not None:
         if y.shape[0] != f.shape[0]:
             raise ValueError('len(y) = {0} != len(f) = {1} '.
                              format(y.shape[0], f.shape[0]))
         distance = _distance_2d
-    #1d
+    # 1d
     else:
         distance = _distance_1d
 
@@ -89,17 +73,14 @@ def unstructured(double[:] f, double[:] bin_edges, double[:] x,
                 if dist >= bin_edges[i] and dist < bin_edges[i+1]:
                     counts[i] += 1
                     variogram[i] += (f[k] - f[j])**2
-    #avoid division by zero
     for i in range(i_max):
+        # avoid division by zero
         if counts[i] == 0:
             counts[i] = 1
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def structured_3d(double[:,:,:] f):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
@@ -116,16 +97,13 @@ def structured_3d(double[:,:,:] f):
                 for l in range(1, l_max-i):
                     counts[l] += 1
                     variogram[l] += (f[i,j,k] - f[i+l,j,k])**2
-    #avoid division by zero
     for i in range(l_max):
+        # avoid division by zero
         if counts[i] == 0:
             counts[i] = 1
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def structured_2d(double[:,:] f):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
@@ -140,16 +118,13 @@ def structured_2d(double[:,:] f):
             for k in range(1, k_max-i):
                 counts[k] += 1
                 variogram[k] += (f[i,j] - f[i+k,j])**2
-    #avoid division by zero
     for i in range(k_max):
+        # avoid division by zero
         if counts[i] == 0:
             counts[i] = 1
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def structured_1d(double[:] f):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = i_max + 1
@@ -162,16 +137,13 @@ def structured_1d(double[:] f):
         for j in range(1, j_max-i):
             counts[j] += 1
             variogram[j] += (f[i] - f[i+j])**2
-    #avoid division by zero
     for i in range(j_max):
+        # avoid division by zero
         if counts[i] == 0:
             counts[i] = 1
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def ma_structured_3d(double[:,:,:] f, bint[:,:,:] mask):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
@@ -189,16 +161,13 @@ def ma_structured_3d(double[:,:,:] f, bint[:,:,:] mask):
                     if not mask[i,j,k] and not mask[i+l,j,k]:
                         counts[l] += 1
                         variogram[l] += (f[i,j,k] - f[i+l,j,k])**2
-    #avoid division by zero
     for i in range(l_max):
+        # avoid division by zero
         if counts[i] == 0:
             counts[i] = 1
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def ma_structured_2d(double[:,:] f, bint[:,:] mask):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
@@ -214,16 +183,13 @@ def ma_structured_2d(double[:,:] f, bint[:,:] mask):
                 if not mask[i,j] and not mask[i+k,j]:
                     counts[k] += 1
                     variogram[k] += (f[i,j] - f[i+k,j])**2
-    #avoid division by zero
     for i in range(k_max):
+        # avoid division by zero
         if counts[i] == 0:
             counts[i] = 1
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
 def ma_structured_1d(double[:] f, bint[:] mask):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = i_max + 1
@@ -237,8 +203,8 @@ def ma_structured_1d(double[:] f, bint[:] mask):
             if not mask[i] and not mask[j]:
                 counts[j] += 1
                 variogram[j] += (f[i] - f[i+j])**2
-    #avoid division by zero
     for i in range(j_max):
+        # avoid division by zero
         if counts[i] == 0:
             counts[i] = 1
         variogram[i] /= (2. * counts[i])

--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -16,25 +16,51 @@ DTYPE = np.double
 ctypedef np.double_t DTYPE_t
 
 
-cdef inline double _distance_1d(double[:] x, double[:] y, double[:] z,
-                               int i, int j) nogil:
+cdef inline double _distance_1d(
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
+    const int i,
+    const int j
+) nogil:
     return sqrt((x[i] - x[j]) * (x[i] - x[j]))
 
-cdef inline double _distance_2d(double[:] x, double[:] y, double[:] z,
-                               int i, int j) nogil:
+cdef inline double _distance_2d(
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
+    const int i,
+    const int j
+) nogil:
     return sqrt((x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]))
 
-cdef inline double _distance_3d(double[:] x, double[:] y, double[:] z,
-                               int i, int j) nogil:
+cdef inline double _distance_3d(
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
+    const int i,
+    const int j
+) nogil:
     return sqrt((x[i] - x[j]) * (x[i] - x[j]) +
                 (y[i] - y[j]) * (y[i] - y[j]) +
                 (z[i] - z[j]) * (z[i] - z[j]))
 
-ctypedef double (*_dist_func)(double[:], double[:], double[:], int, int) nogil
+ctypedef double (*_dist_func)(
+    const double[:],
+    const double[:],
+    const double[:],
+    const int,
+    const int
+) nogil
 
 
-def unstructured(double[:] f, double[:] bin_edges, double[:] x,
-                 double[:] y=None, double[:] z=None):
+def unstructured(
+    const double[:] f,
+    const double[:] bin_edges,
+    const double[:] x,
+    const double[:] y=None,
+    const double[:] z=None
+):
     if x.shape[0] != f.shape[0]:
         raise ValueError('len(x) = {0} != len(f) = {1} '.
                          format(x.shape[0], f.shape[0]))
@@ -81,7 +107,7 @@ def unstructured(double[:] f, double[:] bin_edges, double[:] x,
     return np.asarray(variogram)
 
 
-def structured_3d(double[:,:,:] f):
+def structured_3d(const double[:,:,:] f):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
     cdef int k_max = f.shape[2]
@@ -104,7 +130,7 @@ def structured_3d(double[:,:,:] f):
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-def structured_2d(double[:,:] f):
+def structured_2d(const double[:,:] f):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
     cdef int k_max = i_max + 1
@@ -125,7 +151,7 @@ def structured_2d(double[:,:] f):
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-def structured_1d(double[:] f):
+def structured_1d(const double[:] f):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = i_max + 1
 
@@ -144,7 +170,7 @@ def structured_1d(double[:] f):
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-def ma_structured_3d(double[:,:,:] f, bint[:,:,:] mask):
+def ma_structured_3d(const double[:,:,:] f, const bint[:,:,:] mask):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
     cdef int k_max = f.shape[2]
@@ -168,7 +194,7 @@ def ma_structured_3d(double[:,:,:] f, bint[:,:,:] mask):
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-def ma_structured_2d(double[:,:] f, bint[:,:] mask):
+def ma_structured_2d(const double[:,:] f, const bint[:,:] mask):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = f.shape[1]
     cdef int k_max = i_max + 1
@@ -190,7 +216,7 @@ def ma_structured_2d(double[:,:] f, bint[:,:] mask):
         variogram[i] /= (2. * counts[i])
     return np.asarray(variogram)
 
-def ma_structured_1d(double[:] f, bint[:] mask):
+def ma_structured_1d(const double[:] f, const bint[:] mask):
     cdef int i_max = f.shape[0] - 1
     cdef int j_max = i_max + 1
 

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -34,7 +34,7 @@ def _set_estimator(estimator):
     elif estimator.lower() == "cressie":
         cython_estimator = "c"
     else:
-        raise ValueError(f"Unknown variogram estimator function {estimator}")
+        raise ValueError("Unknown variogram estimator function " + str(estimator))
     return cython_estimator
 
 

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -31,6 +31,8 @@ __all__ = ["vario_estimate_unstructured", "vario_estimate_structured"]
 def _set_estimator(estimator):
     if estimator.lower() == "matheron":
         cython_estimator = "m"
+    elif estimator.lower() == "cressie":
+        cython_estimator = "c"
     else:
         raise ValueError(f"Unknown variogram estimator function {estimator}")
     return cython_estimator
@@ -79,6 +81,7 @@ def vario_estimate_unstructured(
     estimator : :class:`str`, optional
         the estimator function, possible choices:
             * "mathoron"
+            * "cressie"
         Default: "matheron"
 
     Returns
@@ -144,6 +147,7 @@ def vario_estimate_structured(field, direction="x", estimator="matheron"):
     estimator : :class:`str`, optional
         the estimator function, possible choices:
             * "mathoron"
+            * "cressie"
         Default: "matheron"
 
     Returns

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -52,10 +52,20 @@ def vario_estimate_unstructured(
     The algorithm calculates following equation:
 
     .. math::
-       \gamma(r_k) = \frac{1}{2 N} \sum_{i=1}^N (z(\mathbf x_i) -
-       z(\mathbf x_i'))^2, \; \mathrm{ with}
+       \gamma(r_k) = \frac{1}{2 N(r_k)} \sum_{i=1}^{N(r_k)} (z(\mathbf x_i) -
+       z(\mathbf x_i'))^2 \; ,
 
-       r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+
+    Or if the estimator "cressie" was chosen:
+
+    .. math::
+       \gamma(r_k) = \frac{\left(\frac{1}{N(r_k)} \sum_{i=1}^{N(r_k)}
+       \left|z(\mathbf x_i) - z(\mathbf x_i')\right|^{0.5}\right)^4}
+       {0.457 + 0.494 / N(r_k) + 0.045 / N^2(r_k)} \; ,
+
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+    The Cressie estimator is more robust to outliers.
 
     Notes
     -----
@@ -80,8 +90,10 @@ def vario_estimate_unstructured(
         Default: :any:`None`
     estimator : :class:`str`, optional
         the estimator function, possible choices:
-            * "mathoron"
-            * "cressie"
+
+            * "mathoron": the standard method of moments of Matheron
+            * "cressie": an estimator more robust to outliers
+
         Default: "matheron"
 
     Returns
@@ -125,10 +137,20 @@ def vario_estimate_structured(field, direction="x", estimator="matheron"):
     The algorithm calculates following equation:
 
     .. math::
-       \gamma(r_k) = \frac{1}{2 N} \sum_{i=1}^N (z(\mathbf x_i) -
-       z(\mathbf x_i'))^2, \; \mathrm{ with}
+       \gamma(r_k) = \frac{1}{2 N(r_k)} \sum_{i=1}^{N(r_k)} (z(\mathbf x_i) -
+       z(\mathbf x_i'))^2 \; ,
 
-       r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+
+    Or if the estimator "cressie" was chosen:
+
+    .. math::
+       \gamma(r_k) = \frac{\left(\frac{1}{N(r_k)} \sum_{i=1}^{N(r_k)}
+       \left|z(\mathbf x_i) - z(\mathbf x_i')\right|^{0.5}\right)^4}
+       {0.457 + 0.494 / N(r_k) + 0.045 / N^2(r_k)} \; ,
+
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+    The Cressie estimator is more robust to outliers.
 
     Warnings
     --------
@@ -146,8 +168,10 @@ def vario_estimate_structured(field, direction="x", estimator="matheron"):
         the axis over which the variogram will be estimated (x, y, z)
     estimator : :class:`str`, optional
         the estimator function, possible choices:
-            * "mathoron"
-            * "cressie"
+
+            * "mathoron": the standard method of moments of Matheron
+            * "cressie": an estimator more robust to outliers
+
         Default: "matheron"
 
     Returns

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -25,6 +25,7 @@ __all__ = ["vario_estimate_unstructured", "vario_estimate_structured"]
 
 
 def _set_estimator(estimator):
+    """Translate the verbose Python estimator identifier to single char"""
     if estimator.lower() == "matheron":
         cython_estimator = "m"
     elif estimator.lower() == "cressie":

--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,7 @@ CY_MODULES.append(
     Extension(
         "gstools.variogram.estimator",
         [os.path.join("gstools", "variogram", "estimator.pyx")],
+        language="c++",
         include_dirs=[numpy.get_include()],
         extra_compile_args=FLAGS,
         extra_link_args=FLAGS,

--- a/tests/test_variogram_structured.py
+++ b/tests/test_variogram_structured.py
@@ -83,6 +83,11 @@ class TestVariogramstructured(unittest.TestCase):
         except NotImplementedError as e:
             pass
 
+    def test_cressie_1d(self):
+        z = [41.2, 40.2, 39.7, 39.2, 40.1, 38.3, 39.1, 40.0, 41.1, 40.3]
+        gamma = variogram.vario_estimate_structured(z, estimator='cressie')
+        self.assertAlmostEqual(gamma[1], 1.546, places=3)
+
     def test_1d(self):
         # literature values
         z = np.array(
@@ -219,6 +224,31 @@ class TestVariogramstructured(unittest.TestCase):
             self.assertAlmostEqual(gamma_y[-1], var, places=2)
         except NotImplementedError as e:
             pass
+
+    def test_uncorrelated_cressie_2d(self):
+        x = np.linspace(0.0, 100.0, 80)
+        y = np.linspace(0.0, 100.0, 60)
+
+        rng = np.random.RandomState(1479373475)
+        field = rng.rand(len(x), len(y))
+
+        gamma_x = variogram.vario_estimate_structured(
+            field,
+            direction="x",
+            estimator="cressie"
+        )
+        gamma_y = variogram.vario_estimate_structured(
+            field,
+            direction="y",
+            estimator="cressie"
+        )
+
+        # TODO figure out what is going on here
+        var = 0.177
+        self.assertAlmostEqual(gamma_x[0], 0.0, places=1)
+        self.assertAlmostEqual(gamma_x[len(gamma_x) // 2], var, places=1)
+        self.assertAlmostEqual(gamma_y[0], 0.0, places=1)
+        self.assertAlmostEqual(gamma_y[len(gamma_y) // 2], var, places=1)
 
     def test_uncorrelated_3d(self):
         x = np.linspace(0.0, 100.0, 30)


### PR DESCRIPTION
I made a lot of changes to the Cython implementation of the variogram estimators. The code is a lot cleaner now and the two major changes are

- Two types of estimator functions can now be used
- the code for the structured variogram estimation is now unified for the different spatial dimensions