### PR TITLE
Automated versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,95 +1,8 @@
 language: python
 
+# setuptools-scm needs all tags in order to obtain a proper version
 git:
   depth: false
-
-matrix:
-  include:
-    - name: "sdist and coverage"
-      sudo: required
-      language: python
-      python: 3.6
-      services: docker
-      env: OMP_NUM_THREADS=4
-      script:
-        - python -m pip install -U setuptools pytest-cov coveralls
-        - python -m pip install -U numpy==1.17.3 cython==0.29.14
-        - python -m pip install -r requirements.txt
-        - python setup.py sdist -d dist
-        - python setup.py --openmp build_ext --inplace
-        - python -m pytest --cov gstools --cov-report term-missing -v tests/
-        - python -m coveralls
-
-    - name: "Linux py35"
-      sudo: required
-      language: python
-      python: 3.6
-      services: docker
-      env: CIBW_BUILD="cp35-*"
-    - name: "Linux py36"
-      sudo: required
-      language: python
-      python: 3.6
-      services: docker
-      env: CIBW_BUILD="cp36-*"
-    - name: "Linux py37"
-      sudo: required
-      language: python
-      python: 3.6
-      services: docker
-      env: CIBW_BUILD="cp37-*"
-    - name: "Linux py38"
-      sudo: required
-      language: python
-      python: 3.6
-      services: docker
-      env: CIBW_BUILD="cp38-*"
-
-    - name: "MacOS py35"
-      os: osx
-      language: generic
-      env: CIBW_BUILD="cp35-*"
-    - name: "MacOS py36"
-      os: osx
-      language: generic
-      env: CIBW_BUILD="cp36-*"
-    - name: "MacOS py37"
-      os: osx
-      language: generic
-      env: CIBW_BUILD="cp37-*"
-    - name: "MacOS py38"
-      os: osx
-      language: generic
-      env: CIBW_BUILD="cp38-*"
-
-    - name: "Win py35"
-      os: windows
-      language: shell
-      before_install: choco install python3 --version 3.6.8 --no-progress -y
-      env:
-        - PATH=/c/Python36:/c/Python36/Scripts:$PATH
-        - CIBW_BUILD="cp35-*"
-    - name: "Win py36"
-      os: windows
-      language: shell
-      before_install: choco install python3 --version 3.6.8 --no-progress -y
-      env:
-        - PATH=/c/Python36:/c/Python36/Scripts:$PATH
-        - CIBW_BUILD="cp36-*"
-    - name: "Win py37"
-      os: windows
-      language: shell
-      before_install: choco install python3 --version 3.6.8 --no-progress -y
-      env:
-        - PATH=/c/Python36:/c/Python36/Scripts:$PATH
-        - CIBW_BUILD="cp37-*"
-    - name: "Win py38"
-      os: windows
-      language: shell
-      before_install: choco install python3 --version 3.6.8 --no-progress -y
-      env:
-        - PATH=/c/Python36:/c/Python36/Scripts:$PATH
-        - CIBW_BUILD="cp38-*"
 
 env:
   global:
@@ -114,3 +27,87 @@ notifications:
   email:
     recipients:
       - info@geostat-framework.org
+
+jobs:
+  include:
+    - name: "sdist and coverage"
+      sudo: required
+      language: python
+      python: 3.8
+      services: docker
+      env: OMP_NUM_THREADS=4
+      script:
+        - python -m pip install -U setuptools pytest-cov coveralls
+        - python -m pip install -U numpy==1.17.3 cython==0.29.14
+        - python -m pip install -r requirements.txt
+        - python setup.py sdist -d dist
+        - python setup.py --openmp build_ext --inplace
+        - python -m pytest --cov gstools --cov-report term-missing -v tests/
+        - python -m coveralls
+
+    - name: "Linux py35"
+      language: python
+      python: 3.8
+      services: docker
+      env: CIBW_BUILD="cp35-*"
+    - name: "Linux py36"
+      language: python
+      python: 3.8
+      services: docker
+      env: CIBW_BUILD="cp36-*"
+    - name: "Linux py37"
+      language: python
+      python: 3.8
+      services: docker
+      env: CIBW_BUILD="cp37-*"
+    - name: "Linux py38"
+      language: python
+      python: 3.8
+      services: docker
+      env: CIBW_BUILD="cp38-*"
+
+    - name: "MacOS py35"
+      os: osx
+      language: generic
+      env: CIBW_BUILD="cp35-*"
+    - name: "MacOS py36"
+      os: osx
+      language: generic
+      env: CIBW_BUILD="cp36-*"
+    - name: "MacOS py37"
+      os: osx
+      language: generic
+      env: CIBW_BUILD="cp37-*"
+    - name: "MacOS py38"
+      os: osx
+      language: generic
+      env: CIBW_BUILD="cp38-*"
+
+    - name: "Win py35"
+      os: windows
+      language: shell
+      before_install: choco install python3 --version 3.8.0 --no-progress -y
+      env:
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - CIBW_BUILD="cp35-*"
+    - name: "Win py36"
+      os: windows
+      language: shell
+      before_install: choco install python3 --version 3.8.0 --no-progress -y
+      env:
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - CIBW_BUILD="cp36-*"
+    - name: "Win py37"
+      os: windows
+      language: shell
+      before_install: choco install python3 --version 3.8.0 --no-progress -y
+      env:
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - CIBW_BUILD="cp37-*"
+    - name: "Win py38"
+      os: windows
+      language: shell
+      before_install: choco install python3 --version 3.8.0 --no-progress -y
+      env:
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - CIBW_BUILD="cp38-*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ notifications:
 jobs:
   include:
     - name: "sdist and coverage"
-      sudo: required
       language: python
       python: 3.8
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+git:
+  depth: false
+
 matrix:
   include:
     - name: "sdist and coverage"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,7 +48,7 @@ To get the latest development version you can install it directly from GitHub:
 
 .. code-block:: none
 
-    pip install https://github.com/GeoStat-Framework/GSTools/archive/develop.zip
+    pip install git+git://github.com/GeoStat-Framework/GSTools.git@develop
 
 If something went wrong during installation, try the :code:`-I` `flag from pip <https://pip-python3.readthedocs.io/en/latest/reference/pip_install.html?highlight=i#cmdoption-i>`_.
 
@@ -66,8 +66,8 @@ Or for the development version:
 
 .. code-block:: none
 
-    pip install https://github.com/GeoStat-Framework/GSTools/archive/develop.zip
-    pip install -I --no-deps --global-option="--openmp" https://github.com/GeoStat-Framework/GSTools/archive/develop.zip
+    pip install git+git://github.com/GeoStat-Framework/GSTools.git@develop
+    pip install -I --no-deps --global-option="--openmp" git+git://github.com/GeoStat-Framework/GSTools.git@develop
 
 The flags :code:`-I --no-deps` force pip to reinstall gstools but not the dependencies.
 

--- a/gstools/__init__.py
+++ b/gstools/__init__.py
@@ -99,7 +99,6 @@ Estimate the variogram of a given field
    vario_estimate_unstructured
 """
 
-from gstools._version import __version__
 from gstools import field, variogram, random, covmodel, tools, krige, transform
 from gstools.field import SRF
 from gstools.tools import (
@@ -130,6 +129,11 @@ from gstools.covmodel import (
     TPLStable,
 )
 
+try:
+    from gstools._version import __version__
+except ModuleNotFoundError:  # pragma: nocover
+    # package is not installed
+    __version__ = "0.0.0.dev0"
 
 __all__ = ["__version__"]
 __all__ += ["covmodel", "field", "variogram", "krige", "random", "tools"]

--- a/gstools/__init__.py
+++ b/gstools/__init__.py
@@ -133,7 +133,7 @@ try:
     from gstools._version import __version__
 except ModuleNotFoundError:  # pragma: nocover
     # package is not installed
-    __version__ = "0.0.0.dev0"
+    pass
 
 __all__ = ["__version__"]
 __all__ += ["covmodel", "field", "variogram", "krige", "random", "tools"]

--- a/gstools/__init__.py
+++ b/gstools/__init__.py
@@ -133,7 +133,7 @@ try:
     from gstools._version import __version__
 except ModuleNotFoundError:  # pragma: nocover
     # package is not installed
-    pass
+    __version__ = "0.0.0.dev0"
 
 __all__ = ["__version__"]
 __all__ += ["covmodel", "field", "variogram", "krige", "random", "tools"]

--- a/gstools/_version.py
+++ b/gstools/_version.py
@@ -1,2 +1,0 @@
-"""Provide a central version."""
-__version__ = "1.2.0.dev0"

--- a/setup.py
+++ b/setup.py
@@ -14,24 +14,18 @@ import numpy
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
-# version finder ##############################################################
+# helper ######################################################################
+
+
+def local_scheme(version):
+    """Truncate local version (eg. +xyz of 1.0.1.dev1+xyz) for Test PyPI."""
+    return ""
 
 
 def read(*file_paths):
     """Read file data."""
     with codecs.open(os.path.join(HERE, *file_paths), "r") as file_in:
         return file_in.read()
-
-
-def find_version(*file_paths):
-    """Find version without importing module."""
-    version_file = read(*file_paths)
-    version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M
-    )
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
 
 
 # openmp finder ###############################################################
@@ -208,9 +202,6 @@ for ext_m in EXT_MODULES:
 # setup #######################################################################
 
 
-# version import not possible due to cython
-# see: https://packaging.python.org/guides/single-sourcing-package-version/
-VERSION = find_version("gstools", "_version.py")
 DOCLINE = __doc__.split("\n")[0]
 README = read("README.md")
 
@@ -235,7 +226,6 @@ CLASSIFIERS = [
 
 setup(
     name="gstools",
-    version=VERSION,
     maintainer="Lennart Schueler, Sebastian Mueller",
     maintainer_email="info@geostat-framework.org",
     description=DOCLINE,
@@ -249,7 +239,20 @@ setup(
     platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
     include_package_data=True,
     python_requires=">=3.5",
-    setup_requires=["numpy>=1.14.5", "cython>=0.28.3", "setuptools>=41.0.1"],
+    use_scm_version={
+        "root": ".",
+        "relative_to": __file__,
+        "write_to": "gstools/_version.py",
+        "write_to_template": "__version__ = '{version}'",
+        "local_scheme": local_scheme,
+        "fallback_version": "0.0.0.dev0",
+    },
+    setup_requires=[
+        "setuptools_scm",
+        "numpy>=1.14.5",
+        "cython>=0.28.3",
+        "setuptools>=41.0.1",
+    ],
     install_requires=[
         "numpy>=1.14.5",
         "scipy>=1.1.0",


### PR DESCRIPTION
In this PR an automated versioning by `setuptools_scm` is proposed.
This means:
- on release, the version is obtained from the git-tag
- for every development version the version is determined from the last git-tag
  See: https://test.pypi.org/project/gstools/1.1.2.dev155/
- a new `_version.py` is written on every install of the package
- if no version is present a default version of `"0.0.0.dev0"` is set

With this feature, we don't need manual version bumps anymore and the `devN` versions are automatically increased with each commit, so we don't get deploy conflicts with `test.pypi`