### PR TITLE
Implemented directional variograms for `unstructured`

### DIFF
--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -171,7 +171,7 @@ def unstructured(
     const double[:] y=None,
     const double[:] z=None,
     const double[:] angles=None,
-    const double angles_tol_rad=0.0872665,
+    const double angles_tol=0.0872665,
     str estimator_type='m'
 ):
     if x.shape[0] != f.shape[0]:

--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -234,7 +234,7 @@ def unstructured(
                         variogram[i] += estimator_func(f[k] - f[j])
 
     normalization_func(variogram, counts)
-    return np.asarray(variogram)
+    return np.asarray(variogram), np.asarray(counts)
 
 
 def structured(const double[:,:,:] f, str estimator_type='m'):

--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -10,7 +10,7 @@ import numpy as np
 cimport cython
 from cython.parallel import prange, parallel
 from libcpp.vector cimport vector
-from libc.math cimport fabs, sqrt, atan2, acos, asin, sin, cos
+from libc.math cimport fabs, sqrt, atan2, acos, asin, sin, cos, M_PI
 cimport numpy as np
 
 
@@ -70,8 +70,8 @@ cdef inline bint _angle_test_2d(
     cdef double dx = x[i] - x[j]
     cdef double dy = y[i] - y[j]
     # azimuth
-    cdef double phi1 = atan2(dy,dx)
-    cdef double phi2 = atan2(-dy,-dx)
+    cdef double phi1 = atan2(dy,dx) % (2.0 * M_PI)
+    cdef double phi2 = atan2(-dy,-dx) % (2.0 * M_PI)
     # check both directions (+/-)
     cdef bint dir1 = fabs(phi1 - angles[0]) <= angles_tol
     cdef bint dir2 = fabs(phi2 - angles[0]) <= angles_tol
@@ -91,8 +91,8 @@ cdef inline bint _angle_test_3d(
     cdef double dz = z[i] - z[j]
     cdef double dr = sqrt(dx**2 + dy**2 + dz**2)
     # azimuth
-    cdef double phi1 = atan2(dy, dx)
-    cdef double phi2 = atan2(-dy, -dx)
+    cdef double phi1 = atan2(dy, dx) % (2.0 * M_PI)
+    cdef double phi2 = atan2(-dy, -dx) % (2.0 * M_PI)
     # elevation
     cdef double theta1 = acos(dz / dr)
     cdef double theta2 = acos(-dz / dr)

--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -171,7 +171,7 @@ def unstructured(
     const double[:] y=None,
     const double[:] z=None,
     const double[:] angles=None,
-    const double angles_tol=0.0872665,
+    const double angles_tol=0.436332,
     str estimator_type='m'
 ):
     if x.shape[0] != f.shape[0]:

--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -10,7 +10,7 @@ import numpy as np
 cimport cython
 from cython.parallel import prange, parallel
 from libcpp.vector cimport vector
-from libc.math cimport fabs, sqrt
+from libc.math cimport fabs, sqrt, atan2
 cimport numpy as np
 
 
@@ -47,6 +47,49 @@ cdef inline double _distance_3d(
                 (y[i] - y[j]) * (y[i] - y[j]) +
                 (z[i] - z[j]) * (z[i] - z[j]))
 
+cdef inline bint _angle_test_1d(
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
+    const double[:] angles,
+    const double angles_tol,
+    const int i,
+    const int j
+) nogil:
+    return True
+
+cdef inline bint _angle_test_2d(
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
+    const double[:] angles,
+    const double angles_tol,
+    const int i,
+    const int j
+) nogil:
+    cdef double dx = x[i] - x[j]
+    cdef double dy = y[i] - y[j]
+
+    cdef double phi = atan2(dy,dx)
+    return fabs(phi - angles[0]) <= angles_tol
+
+
+cdef inline bint _angle_test_3d(
+    const double[:] x,
+    const double[:] y,
+    const double[:] z,
+    const double[:] angles,
+    const double angles_tol,
+    const int i,
+    const int j
+) nogil:
+    cdef double dx = x[i] - x[j]
+    cdef double dy = y[i] - y[j]
+    cdef double dz = z[i] - z[j]
+
+    cdef double theta = atan2(dz,sqrt(dx + dy))
+    cdef double phi = atan2(dy,dx)
+    return fabs(theta - angles[0]) <= angles_tol and fabs(phi - angles[1]) <= angles_tol
 
 cdef inline double estimator_matheron(const double f_diff) nogil:
     return f_diff * f_diff
@@ -110,6 +153,16 @@ ctypedef double (*_dist_func)(
     const int
 ) nogil
 
+ctypedef bint (*_angle_test_func)(
+    const double[:],
+    const double[:],
+    const double[:],
+    const double[:],
+    const double,
+    const int,
+    const int
+) nogil
+
 
 def unstructured(
     const double[:] f,
@@ -117,6 +170,8 @@ def unstructured(
     const double[:] x,
     const double[:] y=None,
     const double[:] z=None,
+    const double[:] angles=None,
+    const double angles_tol_rad=0.0872665,
     str estimator_type='m'
 ):
     if x.shape[0] != f.shape[0]:
@@ -126,21 +181,35 @@ def unstructured(
         raise ValueError('len(bin_edges) too small')
 
     cdef _dist_func distance
+    cdef _angle_test_func angle_test
+
     # 3d
     if z is not None:
         if z.shape[0] != f.shape[0]:
             raise ValueError('len(z) = {0} != len(f) = {1} '.
                              format(z.shape[0], f.shape[0]))
         distance = _distance_3d
+        angle_test = _angle_test_3d
     # 2d
     elif y is not None:
         if y.shape[0] != f.shape[0]:
             raise ValueError('len(y) = {0} != len(f) = {1} '.
                              format(y.shape[0], f.shape[0]))
         distance = _distance_2d
+        angle_test = _angle_test_2d
     # 1d
     else:
         distance = _distance_1d
+        angle_test = _angle_test_1d
+
+    if angles is not None:
+        if z is not None and angles.size < 2:
+            raise ValueError('3d requested but only one angle given')
+        if y is not None and angles.size < 1:
+            raise ValueError('2d with angle requested but no angle given')
+
+    if angles_tol <= 0:
+        raise ValueError('tolerance for angle search masks must be > 0')
 
     cdef _estimator_func estimator_func = choose_estimator_func(estimator_type)
     cdef _normalization_func normalization_func = (
@@ -160,8 +229,9 @@ def unstructured(
             for k in range(j+1, k_max):
                 dist = distance(x, y, z, k, j)
                 if dist >= bin_edges[i] and dist < bin_edges[i+1]:
-                    counts[i] += 1
-                    variogram[i] += estimator_func(f[k] - f[j])
+                    if angles is None or angle_test(x, y, z, angles, angles_tol, k, j):
+                        counts[i] += 1
+                        variogram[i] += estimator_func(f[k] - f[j])
 
     normalization_func(variogram, counts)
     return np.asarray(variogram)

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -84,7 +84,7 @@ def vario_estimate_unstructured(
         for 2d supply one angle which is azimuth φ (ccw from +x in xy plane)
         for 3d supply two angles which are inclination θ (cw from +z)
         and azimuth φ (ccw from +x in xy plane)
-    angles_tol : :float
+    angles_tol : class:`float`
         the tolerance around the variogram angle to count a point as being
         within this direction from another point (the angular tolerance around
         the directional vector given by angles)

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -42,6 +42,7 @@ def vario_estimate_unstructured(
     sampling_size=None,
     sampling_seed=None,
     estimator="matheron",
+    return_counts=False
 ):
     r"""
     Estimates the variogram on a unstructured grid.
@@ -104,11 +105,16 @@ def vario_estimate_unstructured(
             * "cressie": an estimator more robust to outliers
 
         Default: "matheron"
-
+    return_counts: class:`bool`, optional
+        if set to true, this function will also return the number of data 
+        points found at each lag distance as a third return value
+        Default: False
     Returns
     -------
     :class:`tuple` of :class:`numpy.ndarray`
-        the estimated variogram and the bin centers
+        1. the bin centers
+        2. the estimated variogram values at bin centers
+        (optional) 3. the number of points found at each bin center (see argument return_counts)
     """
     # TODO check_mesh
     field = np.array(field, ndmin=1, dtype=np.double)
@@ -140,12 +146,21 @@ def vario_estimate_unstructured(
 
     cython_estimator = _set_estimator(estimator)
 
-    return (
-        bin_centres,
-        unstructured(
+    estimates, counts = unstructured(
             field, bin_edges, x, y, z, angles, angles_tol, estimator_type=cython_estimator
-        ),
-    )
+        )
+
+    if return_counts:
+        return (
+            bin_centres,
+            estimates,
+            counts
+        )
+    else:
+        return (
+            bin_centres,
+            estimates
+        )
 
 
 def vario_estimate_structured(field, direction="x", estimator="matheron"):

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -38,7 +38,7 @@ def vario_estimate_unstructured(
     field,
     bin_edges,
     angles=None,
-    angles_tol=0.0872665,
+    angles_tol=0.436332,
     sampling_size=None,
     sampling_seed=None,
     estimator="matheron",
@@ -87,7 +87,8 @@ def vario_estimate_unstructured(
     angles_tol : class:`float`
         the tolerance around the variogram angle to count a point as being
         within this direction from another point (the angular tolerance around
-        the directional vector given by angles)
+        the directional vector given by angles) 
+        Default: 25°≈0.436332
     sampling_size : :class:`int` or :any:`None`, optional
         for large input data, this method can take a long
         time to compute the variogram, therefore this argument specifies

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -134,8 +134,9 @@ def vario_estimate_unstructured(
         angles = np.pad(
             angles, (0, dim - angles.size - 1), "constant", constant_values=0.0
         )  # fill with 0 if too less given
-        # correct intervalls for angles (only need upper hemispheres)
-        angles = angles % np.pi
+        # correct intervalls for angles
+        angles[0] = angles[0] % (2 * np.pi)
+        angles[1:] = angles[1:] % np.pi
     elif dim == 1:
         angles = None
 

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -42,7 +42,7 @@ def vario_estimate_unstructured(
     sampling_size=None,
     sampling_seed=None,
     estimator="matheron",
-    return_counts=False
+    return_counts=False,
 ):
     r"""
     Estimates the variogram on a unstructured grid.
@@ -53,7 +53,8 @@ def vario_estimate_unstructured(
        \gamma(r_k) = \frac{1}{2 N(r_k)} \sum_{i=1}^{N(r_k)} (z(\mathbf x_i) -
        z(\mathbf x_i'))^2 \; ,
 
-    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}`
+    being the bins.
 
     Or if the estimator "cressie" was chosen:
 
@@ -62,12 +63,9 @@ def vario_estimate_unstructured(
        \left|z(\mathbf x_i) - z(\mathbf x_i')\right|^{0.5}\right)^4}
        {0.457 + 0.494 / N(r_k) + 0.045 / N^2(r_k)} \; ,
 
-    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}`
+    being the bins.
     The Cressie estimator is more robust to outliers.
-
-    Notes
-    -----
-    Internally uses double precision and also returns doubles.
 
     Parameters
     ----------
@@ -80,15 +78,15 @@ def vario_estimate_unstructured(
         the bins on which the variogram will be calculated
     angles : :class:`numpy.ndarray`
         the angles of the main axis to calculate the variogram for in radians
-        angle definitions from ISO standard 80000-2:2009 
+        angle definitions from ISO standard 80000-2:2009
         for 1d this parameter will have no effect at all
         for 2d supply one angle which is azimuth φ (ccw from +x in xy plane)
-        for 3d supply two angles which are inclination θ (cw from +z)
-        and azimuth φ (ccw from +x in xy plane)
+        for 3d supply two angles which are azimuth φ (ccw from +x in xy plane)
+        and inclination θ (cw from +z)
     angles_tol : class:`float`
         the tolerance around the variogram angle to count a point as being
         within this direction from another point (the angular tolerance around
-        the directional vector given by angles) 
+        the directional vector given by angles)
         Default: 25°≈0.436332
     sampling_size : :class:`int` or :any:`None`, optional
         for large input data, this method can take a long
@@ -106,32 +104,42 @@ def vario_estimate_unstructured(
 
         Default: "matheron"
     return_counts: class:`bool`, optional
-        if set to true, this function will also return the number of data 
+        if set to true, this function will also return the number of data
         points found at each lag distance as a third return value
         Default: False
+
     Returns
     -------
     :class:`tuple` of :class:`numpy.ndarray`
         1. the bin centers
         2. the estimated variogram values at bin centers
-        (optional) 3. the number of points found at each bin center (see argument return_counts)
+        3. (optional) the number of points found at each bin center
+           (see argument return_counts)
+
+    Notes
+    -----
+    Internally uses double precision and also returns doubles.
     """
     # TODO check_mesh
     field = np.array(field, ndmin=1, dtype=np.double)
     bin_edges = np.array(bin_edges, ndmin=1, dtype=np.double)
     x, y, z, dim = pos2xyz(pos, calc_dim=True, dtype=np.double)
-    
+
     bin_centres = (bin_edges[:-1] + bin_edges[1:]) / 2.0
-    
+
     if angles is not None:
-        angles = np.array(angles, ndmin=1, dtype=np.double)
-        if angles.size == 0:
-            angles = np.append(angles, [0,0,0])
-        elif angles.size == 1:
-            angles = np.append(angles, [0,0])
-        elif angles.size == 2:
-            angles = np.append(angles, [0])
-            
+        # there are at most (dim-1) angles
+        angles = np.array(angles, ndmin=1, dtype=np.double).ravel()[
+            : (dim - 1)
+        ]
+        angles = np.pad(
+            angles, (0, dim - angles.size - 1), "constant", constant_values=0.0
+        )
+        # correct intervalls for angles (prepared for n-d)
+        if dim >= 2:
+            angles[0] = angles[0] % (2 * np.pi)  # azimuth in [0, 2pi)
+        if dim >= 3:
+            angles[1:] = angles[1:] % np.pi  # inclinations in [0, pi)
 
     if sampling_size is not None and sampling_size < len(field):
         sampled_idx = np.random.RandomState(sampling_seed).choice(
@@ -147,20 +155,20 @@ def vario_estimate_unstructured(
     cython_estimator = _set_estimator(estimator)
 
     estimates, counts = unstructured(
-            field, bin_edges, x, y, z, angles, angles_tol, estimator_type=cython_estimator
-        )
+        field,
+        bin_edges,
+        x,
+        y,
+        z,
+        angles,
+        angles_tol,
+        estimator_type=cython_estimator,
+    )
 
     if return_counts:
-        return (
-            bin_centres,
-            estimates,
-            counts
-        )
+        return bin_centres, estimates, counts
     else:
-        return (
-            bin_centres,
-            estimates
-        )
+        return bin_centres, estimates
 
 
 def vario_estimate_structured(field, direction="x", estimator="matheron"):
@@ -173,7 +181,8 @@ def vario_estimate_structured(field, direction="x", estimator="matheron"):
        \gamma(r_k) = \frac{1}{2 N(r_k)} \sum_{i=1}^{N(r_k)} (z(\mathbf x_i) -
        z(\mathbf x_i'))^2 \; ,
 
-    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}`
+    being the bins.
 
     Or if the estimator "cressie" was chosen:
 
@@ -182,16 +191,9 @@ def vario_estimate_structured(field, direction="x", estimator="matheron"):
        \left|z(\mathbf x_i) - z(\mathbf x_i')\right|^{0.5}\right)^4}
        {0.457 + 0.494 / N(r_k) + 0.045 / N^2(r_k)} \; ,
 
-    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}` being the bins.
+    with :math:`r_k \leq \| \mathbf x_i - \mathbf x_i' \| < r_{k+1}`
+    being the bins.
     The Cressie estimator is more robust to outliers.
-
-    Warnings
-    --------
-    It is assumed that the field is defined on an equidistant Cartesian grid.
-
-    Notes
-    -----
-    Internally uses double precision and also returns doubles.
 
     Parameters
     ----------
@@ -211,6 +213,14 @@ def vario_estimate_structured(field, direction="x", estimator="matheron"):
     -------
     :class:`numpy.ndarray`
         the estimated variogram along the given direction.
+
+    Warnings
+    --------
+    It is assumed that the field is defined on an equidistant Cartesian grid.
+
+    Notes
+    -----
+    Internally uses double precision and also returns doubles.
     """
     try:
         mask = np.array(field.mask, dtype=np.int32)

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -127,19 +127,17 @@ def vario_estimate_unstructured(
 
     bin_centres = (bin_edges[:-1] + bin_edges[1:]) / 2.0
 
-    if angles is not None:
+    if angles is not None and dim > 1:
         # there are at most (dim-1) angles
-        angles = np.array(angles, ndmin=1, dtype=np.double).ravel()[
-            : (dim - 1)
-        ]
+        angles = np.array(angles, ndmin=1, dtype=np.double)  # type convert
+        angles = angles.ravel()[: (dim - 1)]  # cutoff
         angles = np.pad(
             angles, (0, dim - angles.size - 1), "constant", constant_values=0.0
-        )
-        # correct intervalls for angles (prepared for n-d)
-        if dim >= 2:
-            angles[0] = angles[0] % (2 * np.pi)  # azimuth in [0, 2pi)
-        if dim >= 3:
-            angles[1:] = angles[1:] % np.pi  # inclinations in [0, pi)
+        )  # fill with 0 if too less given
+        # correct intervalls for angles (only need upper hemispheres)
+        angles = angles % np.pi
+    elif dim == 1:
+        angles = None
 
     if sampling_size is not None and sampling_size < len(field):
         sampled_idx = np.random.RandomState(sampling_seed).choice(

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -217,6 +217,101 @@ class TestVariogramUnstructured(unittest.TestCase):
             ValueError, vario_estimate_unstructured, [x], field_e, bins
         )
 
+    def test_angles(self):
+        x = np.array([
+        -4.86210059, -4.1984934 , -3.9246953 , -3.28490663, -2.16332379,
+        -1.87553275, -1.74125124, -1.27224687, -1.20931578, -0.2413368 ,
+         0.03200921,  1.17099773,  1.53863105,  1.64478688,  2.75252136,
+         3.3556915 ,  3.89828775,  4.21485964,  4.5364357 ,  4.79236969]),
+        field = np.array([
+        -1.10318365, -0.53566629, -0.41789049, -1.06167529,  0.38449961,
+        -0.36550477, -0.98905552, -0.19352766,  0.16264266,  0.26920833,
+         0.05379665,  0.71275006,  0.36651935,  0.17366865,  1.20022343,
+         0.79385446,  0.69456069,  1.0733393 ,  0.71191592,  0.71969766])
+        
+        gamma_exp = np.array([
+        0.14260989, 0.18301197, 0.25855841, 0.29990083, 0.67914526,
+        0.60136535, 0.92875492, 1.46910435, 1.10165104])
+        
+        bins = np.arange(0, 10)
+        
+        y = np.zeros_like(x)
+        
+        # test case 1.)
+        #    all along x axis on x axis
+        
+        bin_centres, gamma = vario_estimate_unstructured(
+            (x, y),
+            field,
+            bins,
+            angles=[0]
+        )
+        
+        for i in range(gamma.size):
+            self.assertAlmostEqual(gamma_exp[i], gamma[i], places=3)
 
+
+        # test case 2.)
+        #    all along y axis on y axis but calculation for x axis
+            
+        bin_centres, gamma = vario_estimate_unstructured(
+            (y, x),
+            field,
+            bins,
+            angles=[0]
+        )
+        
+        for i in range(gamma.size):
+            self.assertAlmostEqual(0, gamma[i], places=3)
+            
+        # test case 3.)
+        #    all along y axis on y axis and calculation for y axis
+            
+        bin_centres, gamma = vario_estimate_unstructured(
+            (y, x),
+            field,
+            bins,
+            angles=[np.pi/2.]
+        )
+        
+        for i in range(gamma.size):
+            self.assertAlmostEqual(gamma_exp[i], gamma[i], places=3)
+            
+        # test case 4.)
+        #    data along 45deg axis but calculation for x axis
+            
+        ccos, csin = np.cos(np.pi/4.), np.sin(np.pi/4.)
+        
+        xr = [xx * ccos - yy * csin for xx, yy in zip(x, y)]
+        yr = [xx * csin + yy * ccos for xx, yy in zip(x, y)]
+        
+        bin_centres, gamma = vario_estimate_unstructured(
+            (xr, yr),
+            field,
+            bins,
+            angles=[0]
+        )
+        
+        for i in range(gamma.size):
+            self.assertAlmostEqual(0, gamma[i], places=3)
+            
+        # test case 5.)
+        #    data along 45deg axis and calculation for 45deg
+            
+        ccos, csin = np.cos(np.pi/4.), np.sin(np.pi/4.)
+        
+        xr = [xx * ccos - yy * csin for xx, yy in zip(x, y)]
+        yr = [xx * csin + yy * ccos for xx, yy in zip(x, y)]
+        
+        bin_centres, gamma = vario_estimate_unstructured(
+            (xr, yr),
+            field,
+            bins,
+            angles=[np.pi/4.]
+        )
+        
+        for i in range(gamma.size):
+            self.assertAlmostEqual(gamma_exp[i], gamma[i], places=3)
+            
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -5,12 +5,38 @@ This is a unittest of the variogram module.
 
 import unittest
 import numpy as np
-from gstools import vario_estimate_unstructured
-
+from gstools import vario_estimate_unstructured, Exponential, SRF
+import gstools as gs
 
 class TestVariogramUnstructured(unittest.TestCase):
     def setUp(self):
-        pass
+
+        # this code generates the testdata for the 2D rotation test cases
+        x = np.random.RandomState(19970221).rand(20) * 10.0 - 5
+        y = np.zeros_like(x)
+        model = gs.Exponential(dim=2, var=2, len_scale=8)
+        srf = gs.SRF(model, mean=0, seed=19970221)
+        field = srf((x, y))
+
+        bins = np.arange(10)
+        bin_center, gamma = gs.vario_estimate_unstructured((x, ), field, bins)
+        idx = np.argsort(x)
+        self.test_data_rotation_1 = {'gamma': gamma, 'x': x[idx], 'field': field[idx], 'bins': bins, 'bin_center': bin_center}
+
+        # CODE ABOVE SHOULD GENERATE THIS DATA
+        # x = np.array([
+        # -4.86210059, -4.1984934 , -3.9246953 , -3.28490663, -2.16332379,
+        # -1.87553275, -1.74125124, -1.27224687, -1.20931578, -0.2413368 ,
+        #  0.03200921,  1.17099773,  1.53863105,  1.64478688,  2.75252136,
+        #  3.3556915 ,  3.89828775,  4.21485964,  4.5364357 ,  4.79236969]),
+        # field = np.array([
+        # -1.10318365, -0.53566629, -0.41789049, -1.06167529,  0.38449961,
+        # -0.36550477, -0.98905552, -0.19352766,  0.16264266,  0.26920833,
+        #  0.05379665,  0.71275006,  0.36651935,  0.17366865,  1.20022343,
+        #  0.79385446,  0.69456069,  1.0733393 ,  0.71191592,  0.71969766])
+        # gamma_exp = np.array([
+        # 0.14260989, 0.18301197, 0.25855841, 0.29990083, 0.67914526,
+        # 0.60136535, 0.92875492, 1.46910435, 1.10165104])
 
     def test_doubles(self):
         x = np.arange(1, 11, 1, dtype=np.double)
@@ -217,24 +243,12 @@ class TestVariogramUnstructured(unittest.TestCase):
             ValueError, vario_estimate_unstructured, [x], field_e, bins
         )
 
-    def test_angles(self):
-        x = np.array([
-        -4.86210059, -4.1984934 , -3.9246953 , -3.28490663, -2.16332379,
-        -1.87553275, -1.74125124, -1.27224687, -1.20931578, -0.2413368 ,
-         0.03200921,  1.17099773,  1.53863105,  1.64478688,  2.75252136,
-         3.3556915 ,  3.89828775,  4.21485964,  4.5364357 ,  4.79236969]),
-        field = np.array([
-        -1.10318365, -0.53566629, -0.41789049, -1.06167529,  0.38449961,
-        -0.36550477, -0.98905552, -0.19352766,  0.16264266,  0.26920833,
-         0.05379665,  0.71275006,  0.36651935,  0.17366865,  1.20022343,
-         0.79385446,  0.69456069,  1.0733393 ,  0.71191592,  0.71969766])
-        
-        gamma_exp = np.array([
-        0.14260989, 0.18301197, 0.25855841, 0.29990083, 0.67914526,
-        0.60136535, 0.92875492, 1.46910435, 1.10165104])
-        
-        bins = np.arange(0, 10)
-        
+    def test_angles_2D_x2x(self):
+
+        x = self.test_data_rotation_1['x']
+        field = self.test_data_rotation_1['field']
+        gamma_exp = self.test_data_rotation_1['gamma']
+        bins = self.test_data_rotation_1['bins']
         y = np.zeros_like(x)
         
         # test case 1.)
@@ -250,6 +264,13 @@ class TestVariogramUnstructured(unittest.TestCase):
         for i in range(gamma.size):
             self.assertAlmostEqual(gamma_exp[i], gamma[i], places=3)
 
+    def test_angles_2D_y2x(self):
+
+        x = self.test_data_rotation_1['x']
+        field = self.test_data_rotation_1['field']
+        gamma_exp = self.test_data_rotation_1['gamma']
+        bins = self.test_data_rotation_1['bins']
+        y = np.zeros_like(x)
 
         # test case 2.)
         #    all along y axis on y axis but calculation for x axis
@@ -264,6 +285,14 @@ class TestVariogramUnstructured(unittest.TestCase):
         for i in range(gamma.size):
             self.assertAlmostEqual(0, gamma[i], places=3)
             
+    def test_angles_2D_y2y(self):
+
+        x = self.test_data_rotation_1['x']
+        field = self.test_data_rotation_1['field']
+        gamma_exp = self.test_data_rotation_1['gamma']
+        bins = self.test_data_rotation_1['bins']
+        y = np.zeros_like(x)
+
         # test case 3.)
         #    all along y axis on y axis and calculation for y axis
             
@@ -276,7 +305,16 @@ class TestVariogramUnstructured(unittest.TestCase):
         
         for i in range(gamma.size):
             self.assertAlmostEqual(gamma_exp[i], gamma[i], places=3)
-            
+
+    def test_angles_2D_xy2x(self):
+
+        x = self.test_data_rotation_1['x']
+        field = self.test_data_rotation_1['field']
+        gamma_exp = self.test_data_rotation_1['gamma']
+        bins = self.test_data_rotation_1['bins']
+        y = np.zeros_like(x)
+
+
         # test case 4.)
         #    data along 45deg axis but calculation for x axis
             
@@ -295,6 +333,14 @@ class TestVariogramUnstructured(unittest.TestCase):
         for i in range(gamma.size):
             self.assertAlmostEqual(0, gamma[i], places=3)
             
+    def test_angles_2D_xy2xy(self):
+
+        x = self.test_data_rotation_1['x']
+        field = self.test_data_rotation_1['field']
+        gamma_exp = self.test_data_rotation_1['gamma']
+        bins = self.test_data_rotation_1['bins']
+        y = np.zeros_like(x)
+
         # test case 5.)
         #    data along 45deg axis and calculation for 45deg
             


### PR DESCRIPTION
@MuellerSeb @LSchueler I finished implementing the angle dependent variogram calculation and implemented a few test cases. Calculation is quasi pure C as soon as the calculation arrives at the calculation heavy loops. Defaults for parameters were chosen in order to preserve original behavior and the implementation should add no computational overhead if no angles are requested.

Can one of you do a code review and look at the test cases? 

Tests passed on my system without a problem. 

```
(base) C:\Users\tobia\source\repos\GSTools>python tests/test_variogram_unstructured.py TestVariogramUnstructured.test_angles
.
----------------------------------------------------------------------
Ran 1 test in 0.003s

OK
```

Test values were generated like this:

```python
import numpy as np
import gstools as gs

x = np.random.RandomState(19970221).rand(20) * 10.0 - 5
y = np.zeros_like(x)
model = gs.Exponential(dim=2, var=2, len_scale=8)
srf = gs.SRF(model, mean=0, seed=19970221)
field = srf((x, y))

bins = np.arange(10)
bin_center, gamma = gs.vario_estimate_unstructured((x, ), field, bins)

idx = np.argsort(x)

(gamma, x[idx], field[idx])
```

The implemented test-cases correspond to these "fields":
![image](https://user-images.githubusercontent.com/34371519/80871434-e73cb380-8cac-11ea-9eec-1c1440321ee8.png)

with 
- left being the basis for case 1
- middle being the basis for case 2 and 3
- right being the basis for case 4 and 5.
