### PR TITLE
Krige unification

### DIFF
--- a/examples/06_conditioned_fields/00_condition_ensemble.py
+++ b/examples/06_conditioned_fields/00_condition_ensemble.py
@@ -18,7 +18,7 @@ gridx = np.linspace(0.0, 15.0, 151)
 ###############################################################################
 
 # spatial random field class
-model = gs.Gaussian(dim=1, var=0.5, len_scale=2)
+model = gs.Gaussian(dim=1, var=0.5, len_scale=1.5)
 srf = gs.SRF(model)
 srf.set_condition(cond_pos, cond_val, "ordinary")
 
@@ -34,6 +34,15 @@ plt.plot(gridx, np.full_like(gridx, srf.mean), label="estimated mean")
 plt.plot(gridx, np.mean(fields, axis=0), linestyle=":", label="Ensemble mean")
 plt.plot(gridx, srf.krige_field, linestyle="dashed", label="kriged field")
 plt.scatter(cond_pos, cond_val, color="k", zorder=10, label="Conditions")
+# 99 percent confidence interval
+conf = gs.tools.confidence_scaling(0.99)
+plt.fill_between(
+    gridx,
+    srf.krige_field - conf * np.sqrt(srf.krige_var),
+    srf.krige_field + conf * np.sqrt(srf.krige_var),
+    alpha=0.3,
+    label="99% confidence interval",
+)
 plt.legend()
 plt.show()
 

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -185,7 +185,7 @@ class Field:
         axis_lens : :class:`tuple` or :any:`None`
             axis lengths of the structured mesh if mesh type was changed.
         """
-        x, y, z = pos2xyz(pos, max_dim=self.model.dim)
+        x, y, z = pos2xyz(pos, dtype=np.double, max_dim=self.model.dim)
         pos = xyz2pos(x, y, z)
         mesh_type_gen = mesh_type
         # format the positional arguments of the mesh

--- a/gstools/field/condition.py
+++ b/gstools/field/condition.py
@@ -54,7 +54,7 @@ def ordinary(srf):
     )
     err_field, __ = err_ok(srf.pos, srf.mesh_type)
     cond_field = srf.raw_field + krige_field - err_field
-    info = {"mean": krige_ok.mean}
+    info = {"mean": krige_ok.get_mean()}
     return cond_field, krige_field, err_field, krige_var, info
 
 

--- a/gstools/krige/__init__.py
+++ b/gstools/krige/__init__.py
@@ -10,6 +10,7 @@ Kriging Classes
 .. autosummary::
    :toctree: generated
 
+   Krige
    Simple
    Ordinary
    Universal
@@ -18,6 +19,7 @@ Kriging Classes
 
 ----
 """
+from gstools.krige.base import Krige
 from gstools.krige.methods import (
     Simple,
     Ordinary,
@@ -26,4 +28,4 @@ from gstools.krige.methods import (
     Detrended,
 )
 
-__all__ = ["Simple", "Ordinary", "Universal", "ExtDrift", "Detrended"]
+__all__ = ["Krige", "Simple", "Ordinary", "Universal", "ExtDrift", "Detrended"]

--- a/gstools/krige/methods.py
+++ b/gstools/krige/methods.py
@@ -14,12 +14,7 @@ The following classes are provided
    Detrended
 """
 # pylint: disable=C0103
-import numpy as np
-from scipy.linalg import inv
-from gstools.field.tools import make_anisotropic, rotate_mesh
-from gstools.tools.geometric import pos2xyz, xyz2pos
 from gstools.krige.base import Krige
-from gstools.krige.tools import eval_func, no_trend
 
 __all__ = ["Simple", "Ordinary", "Universal", "ExtDrift", "Detrended"]
 
@@ -46,57 +41,46 @@ class Simple(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
     def __init__(
-        self, model, cond_pos, cond_val, mean=0.0, trend_function=None
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        mean=0.0,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
     ):
         super().__init__(
-            model, cond_pos, cond_val, mean=mean, trend_function=trend_function
-        )
-        self._unbiased = False
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        return inv(self.model.cov_nugget(self._get_dists(self._krige_pos)))
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        return self.model.cov_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-
-    def _post_field(self, field, krige_var):
-        """
-        Postprocessing and saving of kriging field and error variance.
-
-        Parameters
-        ----------
-        field : :class:`numpy.ndarray`
-            Raw kriging field.
-        krige_var : :class:`numpy.ndarray`
-            Raw kriging error variance.
-        """
-        if self.trend_function is no_trend:
-            self.field = field + self.mean
-        else:
-            self.field = (
-                field
-                + self.mean
-                + eval_func(self.trend_function, self.pos, self.mesh_type)
-            )
-        # add the given mean
-        self.krige_var = self.model.sill - krige_var
-
-    @property
-    def _krige_cond(self):
-        """:class:`numpy.ndarray`: The prepared kriging conditions."""
-        return self.cond_val - self.mean - self.cond_trend
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Simple(model={0}, cond_pos={1}, cond_val={2}, mean={3})".format(
-            self.model, self.cond_pos, self.cond_val, self.mean
+            model,
+            cond_pos,
+            cond_val,
+            mean=mean,
+            trend_function=trend_function,
+            unbiased=False,
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
@@ -120,50 +104,43 @@ class Ordinary(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
-    def __init__(self, model, cond_pos, cond_val, trend_function=None):
+    def __init__(
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
+    ):
         super().__init__(
-            model, cond_pos, cond_val, trend_function=trend_function
-        )
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        size = self.cond_no + int(self.unbiased)
-        res = np.empty((size, size), dtype=np.double)
-        res[: self.cond_no, : self.cond_no] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-            res[:, self.cond_no] = 1
-            res[self.cond_no, self.cond_no] = 0
-        return inv(res)
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        chunk_size = len(pos[0]) if chunk_slice[1] is None else chunk_slice[1]
-        chunk_size -= chunk_slice[0]
-        size = self.cond_no + int(self.unbiased)
-        res = np.empty((size, chunk_size), dtype=np.double)
-        res[: self.cond_no, :] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-        return res
-
-    def get_mean(self):
-        """Calculate the estimated mean."""
-        mean_est = np.concatenate(
-            (np.full_like(self.cond_val, self.model.sill), [1])
-        )
-        return np.einsum("i,ij,j", self._krige_cond, self._krige_mat, mean_est)
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Ordinary(model={0}, cond_pos={1}, cond_val={2}".format(
-            self.model, self.cond_pos, self.cond_val
+            model,
+            cond_pos,
+            cond_val,
+            trend_function=trend_function,
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
@@ -200,10 +177,35 @@ class Universal(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
     def __init__(
-        self, model, cond_pos, cond_val, drift_functions, trend_function=None
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        drift_functions,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
     ):
         super().__init__(
             model,
@@ -211,56 +213,9 @@ class Universal(Krige):
             cond_val,
             drift_functions=drift_functions,
             trend_function=trend_function,
-        )
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, size), dtype=np.double)
-        res[: self.cond_no, : self.cond_no] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos)
-        )
-        if self.unbiased:
-            res[self.cond_no, : self.cond_no] = 1
-            res[: self.cond_no, self.cond_no] = 1
-        for i, f in enumerate(self.drift_functions):
-            drift_tmp = f(*self.cond_pos)
-            res[-self.drift_no + i, : self.cond_no] = drift_tmp
-            res[: self.cond_no, -self.drift_no + i] = drift_tmp
-        res[self.cond_no :, self.cond_no :] = 0
-        return inv(res)
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        chunk_size = len(pos[0]) if chunk_slice[1] is None else chunk_slice[1]
-        chunk_size -= chunk_slice[0]
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, chunk_size), dtype=np.double)
-        res[: self.cond_no, :] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-        # trend function need the anisotropic and rotated positions
-        if not self.model.is_isotropic:
-            x, y, z = pos2xyz(pos, max_dim=self.model.dim)
-            y, z = make_anisotropic(self.model.dim, self.model.anis, y, z)
-            if self.model.do_rotation:
-                x, y, z = rotate_mesh(
-                    self.model.dim, self.model.angles, x, y, z
-                )
-            pos = xyz2pos(x, y, z, max_dim=self.model.dim)
-        chunk_pos = list(pos[: self.model.dim])
-        for i in range(self.model.dim):
-            chunk_pos[i] = chunk_pos[i][slice(*chunk_slice)]
-        for i, f in enumerate(self.drift_functions):
-            res[-self.drift_no + i, :] = f(*chunk_pos)
-        return res
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Universal(model={0}, cond_pos={1}, cond_val={2})".format(
-            self.model, self.cond_pos, self.cond_val
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
@@ -292,10 +247,35 @@ class ExtDrift(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
     def __init__(
-        self, model, cond_pos, cond_val, ext_drift, trend_function=None
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        ext_drift,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
     ):
         super().__init__(
             model,
@@ -303,45 +283,13 @@ class ExtDrift(Krige):
             cond_val,
             ext_drift=ext_drift,
             trend_function=trend_function,
-        )
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, size), dtype=np.double)
-        res[: self.cond_no, : self.cond_no] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos)
-        )
-        if self.unbiased:
-            res[self.cond_no, : self.cond_no] = 1
-            res[: self.cond_no, self.cond_no] = 1
-        res[-self.drift_no :, : self.cond_no] = self.cond_ext_drift
-        res[: self.cond_no, -self.drift_no :] = self.cond_ext_drift.T
-        res[self.cond_no :, self.cond_no :] = 0
-        return inv(res)
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        chunk_size = len(pos[0]) if chunk_slice[1] is None else chunk_slice[1]
-        chunk_size -= chunk_slice[0]
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, chunk_size), dtype=np.double)
-        res[: self.cond_no, :] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-        res[-self.drift_no :, :] = ext_drift[:, slice(*chunk_slice)]
-        return res
-
-    def __repr__(self):
-        """Return String representation."""
-        return "ExtDrift(model={0}, cond_pos={1}, cond_val={2})".format(
-            self.model, self.cond_pos, self.cond_val
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
-class Detrended(Simple):
+class Detrended(Krige):
     """
     Detrended simple kriging.
 
@@ -365,17 +313,44 @@ class Detrended(Simple):
         the values of the conditions
     trend_function : :any:`callable`
         The callable trend function. Should have the signiture: f(x, [y, z])
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
-    def __init__(self, model, cond_pos, cond_val, trend_function):
+    def __init__(
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        trend_function,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
+    ):
         super().__init__(
-            model, cond_pos, cond_val, trend_function=trend_function
-        )
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Detrended(model={0} cond_pos={1}, cond_val={2})".format(
-            self.model, self.cond_pos, self.cond_val
+            model,
+            cond_pos,
+            cond_val,
+            trend_function=trend_function,
+            unbiased=False,
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 

--- a/gstools/tools/__init__.py
+++ b/gstools/tools/__init__.py
@@ -19,6 +19,7 @@ Special functions
 ^^^^^^^^^^^^^^^^^
 
 .. autosummary::
+   confidence_scaling
    inc_gamma
    exp_int
    inc_beta
@@ -49,6 +50,7 @@ from gstools.tools.export import (
 )
 
 from gstools.tools.special import (
+    confidence_scaling,
     inc_gamma,
     exp_int,
     inc_beta,
@@ -66,6 +68,7 @@ __all__ = [
     "to_vtk",
     "to_vtk_structured",
     "to_vtk_unstructured",
+    "confidence_scaling",
     "inc_gamma",
     "exp_int",
     "inc_beta",

--- a/gstools/tools/special.py
+++ b/gstools/tools/special.py
@@ -20,6 +20,7 @@ import numpy as np
 from scipy import special as sps
 
 __all__ = [
+    "confidence_scaling",
     "inc_gamma",
     "exp_int",
     "inc_beta",
@@ -32,8 +33,25 @@ __all__ = [
 # special functions ###########################################################
 
 
+def confidence_scaling(per=0.95):
+    """
+    Scaling of standard deviation to get the desired confidence interval.
+
+    Parameters
+    ----------
+    per : :class:`float`, optional
+        Confidence level. The default is 0.95.
+
+    Returns
+    -------
+    :class:`float`
+        Scale to multiply the standard deviation with.
+    """
+    return np.sqrt(2) * sps.erfinv(per)
+
+
 def inc_gamma(s, x):
-    r"""The (upper) incomplete gamma function.
+    r"""Calculate the (upper) incomplete gamma function.
 
     Given by: :math:`\Gamma(s,x) = \int_x^{\infty} t^{s-1}\,e^{-t}\,{\rm d}t`
 
@@ -54,7 +72,7 @@ def inc_gamma(s, x):
 
 
 def exp_int(s, x):
-    r"""The exponential integral :math:`E_s(x)`.
+    r"""Calculate the exponential integral :math:`E_s(x)`.
 
     Given by: :math:`E_s(x) = \int_1^\infty \frac{e^{-xt}}{t^s}\,\mathrm dt`
 
@@ -90,7 +108,7 @@ def exp_int(s, x):
 
 
 def inc_beta(a, b, x):
-    r"""The incomplete Beta function.
+    r"""Calculate the incomplete Beta function.
 
     Given by: :math:`B(a,b;\,x) = \int_0^x t^{a-1}\,(1-t)^{b-1}\,dt`
 
@@ -107,7 +125,7 @@ def inc_beta(a, b, x):
 
 
 def tplstable_cor(r, len_scale, hurst, alpha):
-    r"""The correlation function of the TPLStable model.
+    r"""Calculate the correlation function of the TPLStable model.
 
     Given by the following correlation function:
 


### PR DESCRIPTION
Closes #79 
Fixes #89 

Here comes the great unification of our `krige` submodule:

- [x] Swiss Army Knife for kriging: The `Krige` class now provides everything in one place
- [x] "Kriging the mean" is now possible with the switch `only_mean` in the call routine
- [x] `Simple`/`Ordinary`/`Universal`/`ExtDrift`/`Detrended` are only shortcuts to `Krige` with limited input parameter list
- [x] We now use the `covariance` function to build up the kriging matrix
- [x] An `unbiased` switch was added to enable simple kriging (where the unbiased condition is not given)
- [x] An `exact` switch was added to allow smother results, if a `nugget` is present in the model
- [x] An `cond_err` parameter was added, where measurement error variances can be given for each conditional point
- [x] pseudo-inverse matrix is now used to solve the kriging system (can be disabled by the new switch `pseudo_inv`), this is equal to solving the system with least-squares and prevents numerical errors
- [ ] New examples added
- [ ] New tests added