### PR TITLE
Krige unification

### DIFF
--- a/examples/05_kriging/01_ordinary_kriging.py
+++ b/examples/05_kriging/01_ordinary_kriging.py
@@ -10,14 +10,14 @@ The resulting system of equations for :math:`W` is given by:
 .. math::
 
    \begin{pmatrix}W\\\mu\end{pmatrix} = \begin{pmatrix}
-   \gamma(x_1,x_1) & \cdots & \gamma(x_1,x_n) &1 \\
+   c(x_1,x_1) & \cdots & c(x_1,x_n) &1 \\
    \vdots & \ddots & \vdots  & \vdots \\
-   \gamma(x_n,x_1) & \cdots & \gamma(x_n,x_n) & 1 \\
+   c(x_n,x_1) & \cdots & c(x_n,x_n) & 1 \\
    1 &\cdots& 1 & 0
    \end{pmatrix}^{-1}
-   \begin{pmatrix}\gamma(x_1,x_0) \\ \vdots \\ \gamma(x_n,x_0) \\ 1\end{pmatrix}
+   \begin{pmatrix}c(x_1,x_0) \\ \vdots \\ c(x_n,x_0) \\ 1\end{pmatrix}
 
-Thereby :math:`\gamma(x_i,x_j)` is the semi-variogram of the given observations
+Thereby :math:`c(x_i,x_j)` is the covariance of the given observations
 and :math:`\mu` is a Lagrange multiplier to minimize the kriging error and estimate the mean.
 
 

--- a/examples/05_kriging/05_universal_kriging.py
+++ b/examples/05_kriging/05_universal_kriging.py
@@ -1,6 +1,17 @@
 """
 Universal Kriging
 -----------------
+
+You can give a polynomial order or a list of self defined
+functions representing the internal drift of the given values.
+This drift will be fitted internally during the kriging interpolation.
+
+In the following we are creating artificial data, where a linear drift
+was added. The resulting samples are then used as input for Universal kriging.
+
+The "linear" drift is then estimated during the interpolation.
+To access only the estimated mean/drift, we provide a switch `only_mean`
+in the call routine.
 """
 import numpy as np
 from gstools import SRF, Gaussian, krige
@@ -21,4 +32,8 @@ ax = krig.plot()
 ax.scatter(cond_pos, cond_val, color="k", zorder=10, label="Conditions")
 ax.plot(gridx, gridx * 0.1 + 1, ":", label="linear drift")
 ax.plot(gridx, drift_field, "--", label="original field")
+
+mean, mean_err = krig(gridx, only_mean=True)
+ax.plot(gridx, mean, label="estimated drift")
+
 ax.legend()

--- a/examples/05_kriging/08_measurement_errors.py
+++ b/examples/05_kriging/08_measurement_errors.py
@@ -1,0 +1,58 @@
+r"""
+Incorporating measurement errors
+--------------------------------
+
+To incorporate the nugget effect and/or given measurement errors,
+one can set `exact` to `False` and provide either individual measurement errors
+for each point or set the nugget as a constant measurement error everywhere.
+
+In the following we will show the influence of the nugget and
+measurement errors.
+
+Note, that the given measurement errors need to be smaller than the nugget
+of the model.
+"""
+
+import numpy as np
+import gstools as gs
+
+# condtions
+cond_pos = [0.3, 1.1, 1.9, 3.3, 4.7]
+cond_val = [0.47, 0.74, 0.56, 1.47, 1.74]
+cond_err = [0.01, 0.0, 0.1, 0.05, 0]
+# resulting grid
+gridx = np.linspace(0.0, 15.0, 151)
+# spatial random field class
+model = gs.Gaussian(dim=1, var=0.9, len_scale=1, nugget=0.1)
+
+###############################################################################
+# Here we will use Simple kriging (`unbiased=False`) to interpolate the given
+# conditions.
+
+krig = gs.krige.Krige(
+    model=model,
+    cond_pos=cond_pos,
+    cond_val=cond_val,
+    mean=1,
+    unbiased=False,
+    exact=False,
+    cond_err=cond_err,
+)
+krig(gridx, only_mean=False)
+
+###############################################################################
+# Let's plot the data. You can see, that the estimated values differ more from
+# the input, when the given measurement errors get bigger.
+# In addition we plot the standard deviation.
+
+ax = krig.plot()
+ax.scatter(cond_pos, cond_val, color="k", zorder=10, label="Conditions")
+ax.fill_between(
+    gridx,
+    # plus/minus standard deviation (70 percent confidence interval)
+    krig.field - np.sqrt(krig.krige_var),
+    krig.field + np.sqrt(krig.krige_var),
+    alpha=0.3,
+    label="Standard deviation",
+)
+ax.legend()

--- a/examples/05_kriging/08_measurement_errors.py
+++ b/examples/05_kriging/08_measurement_errors.py
@@ -8,9 +8,6 @@ for each point or set the nugget as a constant measurement error everywhere.
 
 In the following we will show the influence of the nugget and
 measurement errors.
-
-Note, that the given measurement errors need to be smaller than the nugget
-of the model.
 """
 
 import numpy as np
@@ -38,7 +35,7 @@ krig = gs.krige.Krige(
     exact=False,
     cond_err=cond_err,
 )
-krig(gridx, only_mean=False)
+krig(gridx)
 
 ###############################################################################
 # Let's plot the data. You can see, that the estimated values differ more from

--- a/examples/05_kriging/09_pseudo_inverse.py
+++ b/examples/05_kriging/09_pseudo_inverse.py
@@ -1,0 +1,38 @@
+r"""
+Redundant data and pseudo-inverse
+---------------------------------
+
+It can happen, that the kriging system gets numerically unstable.
+One reason could be, that the input data contains redundant conditioning points
+that hold different values.
+
+To smoothly deal with such situations, you can switch on using the pseuodo
+inverse for the kriging matrix.
+
+This will result in the average value for the redundant data.
+
+Example
+^^^^^^^
+
+In the following we have two different values at the same location.
+The resulting kriging field will hold the average at this point.
+"""
+import numpy as np
+from gstools import Gaussian, krige
+
+# condtions
+cond_pos = [0.3, 1.9, 1.1, 3.3, 1.1]
+cond_val = [0.47, 0.56, 0.74, 1.47, 1.14]
+# resulting grid
+gridx = np.linspace(0.0, 8.0, 81)
+# spatial random field class
+model = Gaussian(dim=1, var=0.5, len_scale=1)
+
+###############################################################################
+krig = krige.Ordinary(model, cond_pos=cond_pos, cond_val=cond_val)
+krig(gridx)
+
+###############################################################################
+ax = krig.plot()
+ax.scatter(cond_pos, cond_val, color="k", zorder=10, label="Conditions")
+ax.legend()

--- a/examples/05_kriging/09_pseudo_inverse.py
+++ b/examples/05_kriging/09_pseudo_inverse.py
@@ -6,8 +6,8 @@ It can happen, that the kriging system gets numerically unstable.
 One reason could be, that the input data contains redundant conditioning points
 that hold different values.
 
-To smoothly deal with such situations, you can switch on using the pseuodo
-inverse for the kriging matrix.
+To smoothly deal with such situations, you can use the pseudo
+inverse for the kriging matrix, which is enabled by default.
 
 This will result in the average value for the redundant data.
 

--- a/examples/05_kriging/README.rst
+++ b/examples/05_kriging/README.rst
@@ -46,9 +46,11 @@ the features you want:
   use the pseudo-inverse of the matrix. Then redundant conditional values will automatically
   be averaged.
 
-All mentioned features can be combined within the :any:`Krige` class.
-All other kriging classes are just shortcuts to this class with a limited list
-of input parameters.
+.. note::
+
+   All mentioned features can be combined within the :any:`Krige` class.
+   All other kriging classes are just shortcuts to this class with a limited list
+   of input parameters.
 
 The routines for kriging are almost identical to the routines for spatial random fields,
 with regard to their handling.

--- a/examples/05_kriging/README.rst
+++ b/examples/05_kriging/README.rst
@@ -3,7 +3,8 @@
 Tutorial 5: Kriging
 ===================
 
-The subpackage :py:mod:`gstools.krige` provides routines for Gaussian process regression, also known as kriging.
+The subpackage :py:mod:`gstools.krige` provides routines for Gaussian process regression,
+also known as kriging.
 Kriging is a method of data interpolation based on predefined covariance models.
 
 The aim of kriging is to derive the value of a field at some point :math:`x_0`,
@@ -19,8 +20,38 @@ The weights :math:`W = (w_1,\ldots,w_n)` depent on the given covariance model an
 
 The different kriging approaches provide different ways of calculating :math:`W`.
 
+The :any:`Krige` class provides everything in one place and you can switch on/off
+the features you want:
 
-The routines for kriging are almost identical to the routines for spatial random fields.
+* `unbiased`: the weights have to sum up to `1`. If true, this results in
+  :any:`Ordinary` kriging, where the mean is estimated, otherwise it will result in
+  :any:`Simple` kriging, where the mean has to be given.
+* `drift_functions`: you can give a polynomial order or a list of self defined
+  functions representing the internal drift of the given values. This drift will
+  be fitted internally during the kriging interpolation. This results in :any:`Universal` kriging.
+* `ext_drift`: You can also give an external drift per point to the routine.
+  In contrast to the internal drift, that is evaluated at the desired points with
+  the given functions, the external drift has to given for each point form an "external"
+  source. This results in :any:`ExtDrift` kriging.
+* `trend_function`: If you already have fitted a trend model, that is provided as a
+  callable, you can give it to the kriging routine. This trend is subtracted from the
+  conditional values before the kriging is done, meaning, that only the residuals are
+  used for kriging. This can be used with separate regression of your data.
+  This results in :any:`Detrended` kriging.
+* `exact` and `cond_err`: To incorporate the nugget effect and/or measurement errors,
+  one can set `exact` to `False` and provide either individual measurement errors
+  for each point or set the nugget as a constant measurement error everywhere.
+* `pseudo_inv`: Sometimes the inversion of the kriging matrix can be numerically unstable.
+  This occures for examples in cases of redundant input values. In this case we provide a switch to
+  use the pseudo-inverse of the matrix. Then redundant conditional values will automatically
+  be averaged.
+
+All mentioned features can be combined within the :any:`Krige` class.
+All other kriging classes are just shortcuts to this class with a limited list
+of input parameters.
+
+The routines for kriging are almost identical to the routines for spatial random fields,
+with regard to their handling.
 First you define a covariance model, as described in :ref:`tutorial_02_cov`,
 then you initialize the kriging class with this model:
 
@@ -47,6 +78,7 @@ The following kriging methods are provided within the
 submodule :any:`gstools.krige`.
 
 .. autosummary::
+    Krige
     Simple
     Ordinary
     Universal

--- a/examples/06_conditioned_fields/00_condition_ensemble.py
+++ b/examples/06_conditioned_fields/00_condition_ensemble.py
@@ -18,7 +18,7 @@ gridx = np.linspace(0.0, 15.0, 151)
 ###############################################################################
 
 # spatial random field class
-model = gs.Gaussian(dim=1, var=0.5, len_scale=2)
+model = gs.Gaussian(dim=1, var=0.5, len_scale=1.5)
 srf = gs.SRF(model)
 srf.set_condition(cond_pos, cond_val, "ordinary")
 
@@ -34,6 +34,15 @@ plt.plot(gridx, np.full_like(gridx, srf.mean), label="estimated mean")
 plt.plot(gridx, np.mean(fields, axis=0), linestyle=":", label="Ensemble mean")
 plt.plot(gridx, srf.krige_field, linestyle="dashed", label="kriged field")
 plt.scatter(cond_pos, cond_val, color="k", zorder=10, label="Conditions")
+# 99 percent confidence interval
+conf = gs.tools.confidence_scaling(0.99)
+plt.fill_between(
+    gridx,
+    srf.krige_field - conf * np.sqrt(srf.krige_var),
+    srf.krige_field + conf * np.sqrt(srf.krige_var),
+    alpha=0.3,
+    label="99% confidence interval",
+)
 plt.legend()
 plt.show()
 

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -185,7 +185,7 @@ class Field:
         axis_lens : :class:`tuple` or :any:`None`
             axis lengths of the structured mesh if mesh type was changed.
         """
-        x, y, z = pos2xyz(pos, max_dim=self.model.dim)
+        x, y, z = pos2xyz(pos, dtype=np.double, max_dim=self.model.dim)
         pos = xyz2pos(x, y, z)
         mesh_type_gen = mesh_type
         # format the positional arguments of the mesh

--- a/gstools/field/condition.py
+++ b/gstools/field/condition.py
@@ -54,7 +54,7 @@ def ordinary(srf):
     )
     err_field, __ = err_ok(srf.pos, srf.mesh_type)
     cond_field = srf.raw_field + krige_field - err_field
-    info = {"mean": krige_ok.mean}
+    info = {"mean": krige_ok.get_mean()}
     return cond_field, krige_field, err_field, krige_var, info
 
 

--- a/gstools/krige/__init__.py
+++ b/gstools/krige/__init__.py
@@ -10,6 +10,7 @@ Kriging Classes
 .. autosummary::
    :toctree: generated
 
+   Krige
    Simple
    Ordinary
    Universal
@@ -18,6 +19,7 @@ Kriging Classes
 
 ----
 """
+from gstools.krige.base import Krige
 from gstools.krige.methods import (
     Simple,
     Ordinary,
@@ -26,4 +28,4 @@ from gstools.krige.methods import (
     Detrended,
 )
 
-__all__ = ["Simple", "Ordinary", "Universal", "ExtDrift", "Detrended"]
+__all__ = ["Krige", "Simple", "Ordinary", "Universal", "ExtDrift", "Detrended"]

--- a/gstools/krige/base.py
+++ b/gstools/krige/base.py
@@ -80,7 +80,6 @@ class Krige(Field):
         The measurement error at the conditioning points.
         Either "nugget" to apply the model-nugget, a single value applied to
         all points or an array with individual values for each point.
-        The measurement error has to be <= nugget.
         The "exact=True" variant only works with "cond_err='nugget'".
         Default: "nugget"
     pseudo_inv : :class:`bool`, optional
@@ -527,10 +526,6 @@ class Krige(Field):
                         "krige.cond_err: wrong number of measurement errors."
                     )
                 self._cond_err = value
-            if np.any(self._cond_err > self.model.nugget):
-                raise ValueError(
-                    "krige.cond_err: measurement errors need to be <= nugget."
-                )
 
     @property
     def cond_no(self):

--- a/gstools/krige/base.py
+++ b/gstools/krige/base.py
@@ -618,6 +618,12 @@ class Krige(Field):
         if not callable(trend_function):
             raise ValueError("Detrended kriging: trend function not callable.")
         self._trend_function = trend_function
+        # apply trend_function instantly (if cond_pos already set)
+        if self._cond_pos is not None:
+            if self._trend_function is no_trend:
+                self._cond_trend = 0.0
+            else:
+                self._cond_trend = self._trend_function(*self.cond_pos)
 
     @property
     def name(self):

--- a/gstools/krige/methods.py
+++ b/gstools/krige/methods.py
@@ -14,12 +14,7 @@ The following classes are provided
    Detrended
 """
 # pylint: disable=C0103
-import numpy as np
-from scipy.linalg import inv
-from gstools.field.tools import make_anisotropic, rotate_mesh
-from gstools.tools.geometric import pos2xyz, xyz2pos
 from gstools.krige.base import Krige
-from gstools.krige.tools import eval_func, no_trend
 
 __all__ = ["Simple", "Ordinary", "Universal", "ExtDrift", "Detrended"]
 
@@ -46,57 +41,46 @@ class Simple(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
     def __init__(
-        self, model, cond_pos, cond_val, mean=0.0, trend_function=None
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        mean=0.0,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
     ):
         super().__init__(
-            model, cond_pos, cond_val, mean=mean, trend_function=trend_function
-        )
-        self._unbiased = False
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        return inv(self.model.cov_nugget(self._get_dists(self._krige_pos)))
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        return self.model.cov_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-
-    def _post_field(self, field, krige_var):
-        """
-        Postprocessing and saving of kriging field and error variance.
-
-        Parameters
-        ----------
-        field : :class:`numpy.ndarray`
-            Raw kriging field.
-        krige_var : :class:`numpy.ndarray`
-            Raw kriging error variance.
-        """
-        if self.trend_function is no_trend:
-            self.field = field + self.mean
-        else:
-            self.field = (
-                field
-                + self.mean
-                + eval_func(self.trend_function, self.pos, self.mesh_type)
-            )
-        # add the given mean
-        self.krige_var = self.model.sill - krige_var
-
-    @property
-    def _krige_cond(self):
-        """:class:`numpy.ndarray`: The prepared kriging conditions."""
-        return self.cond_val - self.mean - self.cond_trend
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Simple(model={0}, cond_pos={1}, cond_val={2}, mean={3})".format(
-            self.model, self.cond_pos, self.cond_val, self.mean
+            model,
+            cond_pos,
+            cond_val,
+            mean=mean,
+            trend_function=trend_function,
+            unbiased=False,
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
@@ -120,50 +104,43 @@ class Ordinary(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
-    def __init__(self, model, cond_pos, cond_val, trend_function=None):
+    def __init__(
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
+    ):
         super().__init__(
-            model, cond_pos, cond_val, trend_function=trend_function
-        )
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        size = self.cond_no + int(self.unbiased)
-        res = np.empty((size, size), dtype=np.double)
-        res[: self.cond_no, : self.cond_no] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-            res[:, self.cond_no] = 1
-            res[self.cond_no, self.cond_no] = 0
-        return inv(res)
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        chunk_size = len(pos[0]) if chunk_slice[1] is None else chunk_slice[1]
-        chunk_size -= chunk_slice[0]
-        size = self.cond_no + int(self.unbiased)
-        res = np.empty((size, chunk_size), dtype=np.double)
-        res[: self.cond_no, :] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-        return res
-
-    def get_mean(self):
-        """Calculate the estimated mean."""
-        mean_est = np.concatenate(
-            (np.full_like(self.cond_val, self.model.sill), [1])
-        )
-        return np.einsum("i,ij,j", self._krige_cond, self._krige_mat, mean_est)
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Ordinary(model={0}, cond_pos={1}, cond_val={2}".format(
-            self.model, self.cond_pos, self.cond_val
+            model,
+            cond_pos,
+            cond_val,
+            trend_function=trend_function,
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
@@ -200,10 +177,35 @@ class Universal(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
     def __init__(
-        self, model, cond_pos, cond_val, drift_functions, trend_function=None
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        drift_functions,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
     ):
         super().__init__(
             model,
@@ -211,56 +213,9 @@ class Universal(Krige):
             cond_val,
             drift_functions=drift_functions,
             trend_function=trend_function,
-        )
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, size), dtype=np.double)
-        res[: self.cond_no, : self.cond_no] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos)
-        )
-        if self.unbiased:
-            res[self.cond_no, : self.cond_no] = 1
-            res[: self.cond_no, self.cond_no] = 1
-        for i, f in enumerate(self.drift_functions):
-            drift_tmp = f(*self.cond_pos)
-            res[-self.drift_no + i, : self.cond_no] = drift_tmp
-            res[: self.cond_no, -self.drift_no + i] = drift_tmp
-        res[self.cond_no :, self.cond_no :] = 0
-        return inv(res)
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        chunk_size = len(pos[0]) if chunk_slice[1] is None else chunk_slice[1]
-        chunk_size -= chunk_slice[0]
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, chunk_size), dtype=np.double)
-        res[: self.cond_no, :] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-        # trend function need the anisotropic and rotated positions
-        if not self.model.is_isotropic:
-            x, y, z = pos2xyz(pos, max_dim=self.model.dim)
-            y, z = make_anisotropic(self.model.dim, self.model.anis, y, z)
-            if self.model.do_rotation:
-                x, y, z = rotate_mesh(
-                    self.model.dim, self.model.angles, x, y, z
-                )
-            pos = xyz2pos(x, y, z, max_dim=self.model.dim)
-        chunk_pos = list(pos[: self.model.dim])
-        for i in range(self.model.dim):
-            chunk_pos[i] = chunk_pos[i][slice(*chunk_slice)]
-        for i, f in enumerate(self.drift_functions):
-            res[-self.drift_no + i, :] = f(*chunk_pos)
-        return res
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Universal(model={0}, cond_pos={1}, cond_val={2})".format(
-            self.model, self.cond_pos, self.cond_val
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
@@ -292,10 +247,35 @@ class ExtDrift(Krige):
         from the conditions before kriging is applied.
         This can be used for regression kriging, where the trend function
         is determined by an external regression algorithm.
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
     def __init__(
-        self, model, cond_pos, cond_val, ext_drift, trend_function=None
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        ext_drift,
+        trend_function=None,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
     ):
         super().__init__(
             model,
@@ -303,45 +283,13 @@ class ExtDrift(Krige):
             cond_val,
             ext_drift=ext_drift,
             trend_function=trend_function,
-        )
-
-    def _get_krige_mat(self):
-        """Calculate the inverse matrix of the kriging equation."""
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, size), dtype=np.double)
-        res[: self.cond_no, : self.cond_no] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos)
-        )
-        if self.unbiased:
-            res[self.cond_no, : self.cond_no] = 1
-            res[: self.cond_no, self.cond_no] = 1
-        res[-self.drift_no :, : self.cond_no] = self.cond_ext_drift
-        res[: self.cond_no, -self.drift_no :] = self.cond_ext_drift.T
-        res[self.cond_no :, self.cond_no :] = 0
-        return inv(res)
-
-    def _get_krige_vecs(self, pos, chunk_slice=(0, None), ext_drift=None):
-        """Calculate the RHS of the kriging equation."""
-        chunk_size = len(pos[0]) if chunk_slice[1] is None else chunk_slice[1]
-        chunk_size -= chunk_slice[0]
-        size = self.cond_no + int(self.unbiased) + self.drift_no
-        res = np.empty((size, chunk_size), dtype=np.double)
-        res[: self.cond_no, :] = self.model.vario_nugget(
-            self._get_dists(self._krige_pos, pos, chunk_slice)
-        )
-        if self.unbiased:
-            res[self.cond_no, :] = 1
-        res[-self.drift_no :, :] = ext_drift[:, slice(*chunk_slice)]
-        return res
-
-    def __repr__(self):
-        """Return String representation."""
-        return "ExtDrift(model={0}, cond_pos={1}, cond_val={2})".format(
-            self.model, self.cond_pos, self.cond_val
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 
-class Detrended(Simple):
+class Detrended(Krige):
     """
     Detrended simple kriging.
 
@@ -365,17 +313,44 @@ class Detrended(Simple):
         the values of the conditions
     trend_function : :any:`callable`
         The callable trend function. Should have the signiture: f(x, [y, z])
+    exact : :class:`bool`, optional
+        Whether the interpolator should reproduce the exact input values.
+        If `False`, `cond_err` is interpreted as measurement error
+        at the conditioning points and the result will be more smooth.
+        Default: False
+    cond_err : :class:`str`, :class :class:`float` or :class:`list`, optional
+        The measurement error at the conditioning points.
+        Either "nugget" to apply the model-nugget, a single value applied to
+        all points or an array with individual values for each point.
+        The measurement error has to be <= nugget.
+        The "exact=True" variant only works with "cond_err='nugget'".
+        Default: "nugget"
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability,
+        but can take more time.
+        Default: True
     """
 
-    def __init__(self, model, cond_pos, cond_val, trend_function):
+    def __init__(
+        self,
+        model,
+        cond_pos,
+        cond_val,
+        trend_function,
+        exact=False,
+        cond_err="nugget",
+        pseudo_inv=True,
+    ):
         super().__init__(
-            model, cond_pos, cond_val, trend_function=trend_function
-        )
-
-    def __repr__(self):
-        """Return String representation."""
-        return "Detrended(model={0} cond_pos={1}, cond_val={2})".format(
-            self.model, self.cond_pos, self.cond_val
+            model,
+            cond_pos,
+            cond_val,
+            trend_function=trend_function,
+            unbiased=False,
+            exact=exact,
+            cond_err=cond_err,
+            pseudo_inv=pseudo_inv,
         )
 
 

--- a/gstools/krige/methods.py
+++ b/gstools/krige/methods.py
@@ -55,9 +55,17 @@ class Simple(Krige):
         Default: "nugget"
     pseudo_inv : :class:`bool`, optional
         Whether the kriging system is solved with the pseudo inverted
-        kriging matrix. If `True`, this leads to more numerical stability,
-        but can take more time.
+        kriging matrix. If `True`, this leads to more numerical stability
+        and redundant points are averaged. But it can take more time.
         Default: True
+    pseudo_inv_type : :class:`int`, optional
+        Here you can select the algorithm to compute the pseudo-inverse matrix:
+
+            * `1`: use `pinv` from `scipy` which uses `lstsq`
+            * `2`: use `pinv2` from `scipy` which uses `SVD`
+            * `3`: use `pinvh` from `scipy` which uses eigen-values
+
+        Default: `1`
     """
 
     def __init__(
@@ -70,6 +78,7 @@ class Simple(Krige):
         exact=False,
         cond_err="nugget",
         pseudo_inv=True,
+        pseudo_inv_type=1,
     ):
         super().__init__(
             model,
@@ -81,6 +90,7 @@ class Simple(Krige):
             exact=exact,
             cond_err=cond_err,
             pseudo_inv=pseudo_inv,
+            pseudo_inv_type=pseudo_inv_type,
         )
 
 
@@ -118,9 +128,17 @@ class Ordinary(Krige):
         Default: "nugget"
     pseudo_inv : :class:`bool`, optional
         Whether the kriging system is solved with the pseudo inverted
-        kriging matrix. If `True`, this leads to more numerical stability,
-        but can take more time.
+        kriging matrix. If `True`, this leads to more numerical stability
+        and redundant points are averaged. But it can take more time.
         Default: True
+    pseudo_inv_type : :class:`int`, optional
+        Here you can select the algorithm to compute the pseudo-inverse matrix:
+
+            * `1`: use `pinv` from `scipy` which uses `lstsq`
+            * `2`: use `pinv2` from `scipy` which uses `SVD`
+            * `3`: use `pinvh` from `scipy` which uses eigen-values
+
+        Default: `1`
     """
 
     def __init__(
@@ -132,6 +150,7 @@ class Ordinary(Krige):
         exact=False,
         cond_err="nugget",
         pseudo_inv=True,
+        pseudo_inv_type=1,
     ):
         super().__init__(
             model,
@@ -141,6 +160,7 @@ class Ordinary(Krige):
             exact=exact,
             cond_err=cond_err,
             pseudo_inv=pseudo_inv,
+            pseudo_inv_type=pseudo_inv_type,
         )
 
 
@@ -191,9 +211,17 @@ class Universal(Krige):
         Default: "nugget"
     pseudo_inv : :class:`bool`, optional
         Whether the kriging system is solved with the pseudo inverted
-        kriging matrix. If `True`, this leads to more numerical stability,
-        but can take more time.
+        kriging matrix. If `True`, this leads to more numerical stability
+        and redundant points are averaged. But it can take more time.
         Default: True
+    pseudo_inv_type : :class:`int`, optional
+        Here you can select the algorithm to compute the pseudo-inverse matrix:
+
+            * `1`: use `pinv` from `scipy` which uses `lstsq`
+            * `2`: use `pinv2` from `scipy` which uses `SVD`
+            * `3`: use `pinvh` from `scipy` which uses eigen-values
+
+        Default: `1`
     """
 
     def __init__(
@@ -206,6 +234,7 @@ class Universal(Krige):
         exact=False,
         cond_err="nugget",
         pseudo_inv=True,
+        pseudo_inv_type=1,
     ):
         super().__init__(
             model,
@@ -216,6 +245,7 @@ class Universal(Krige):
             exact=exact,
             cond_err=cond_err,
             pseudo_inv=pseudo_inv,
+            pseudo_inv_type=pseudo_inv_type,
         )
 
 
@@ -261,9 +291,17 @@ class ExtDrift(Krige):
         Default: "nugget"
     pseudo_inv : :class:`bool`, optional
         Whether the kriging system is solved with the pseudo inverted
-        kriging matrix. If `True`, this leads to more numerical stability,
-        but can take more time.
+        kriging matrix. If `True`, this leads to more numerical stability
+        and redundant points are averaged. But it can take more time.
         Default: True
+    pseudo_inv_type : :class:`int`, optional
+        Here you can select the algorithm to compute the pseudo-inverse matrix:
+
+            * `1`: use `pinv` from `scipy` which uses `lstsq`
+            * `2`: use `pinv2` from `scipy` which uses `SVD`
+            * `3`: use `pinvh` from `scipy` which uses eigen-values
+
+        Default: `1`
     """
 
     def __init__(
@@ -276,6 +314,7 @@ class ExtDrift(Krige):
         exact=False,
         cond_err="nugget",
         pseudo_inv=True,
+        pseudo_inv_type=1,
     ):
         super().__init__(
             model,
@@ -286,6 +325,7 @@ class ExtDrift(Krige):
             exact=exact,
             cond_err=cond_err,
             pseudo_inv=pseudo_inv,
+            pseudo_inv_type=pseudo_inv_type,
         )
 
 
@@ -327,9 +367,17 @@ class Detrended(Krige):
         Default: "nugget"
     pseudo_inv : :class:`bool`, optional
         Whether the kriging system is solved with the pseudo inverted
-        kriging matrix. If `True`, this leads to more numerical stability,
-        but can take more time.
+        kriging matrix. If `True`, this leads to more numerical stability
+        and redundant points are averaged. But it can take more time.
         Default: True
+    pseudo_inv_type : :class:`int`, optional
+        Here you can select the algorithm to compute the pseudo-inverse matrix:
+
+            * `1`: use `pinv` from `scipy` which uses `lstsq`
+            * `2`: use `pinv2` from `scipy` which uses `SVD`
+            * `3`: use `pinvh` from `scipy` which uses eigen-values
+
+        Default: `1`
     """
 
     def __init__(
@@ -341,6 +389,7 @@ class Detrended(Krige):
         exact=False,
         cond_err="nugget",
         pseudo_inv=True,
+        pseudo_inv_type=1,
     ):
         super().__init__(
             model,
@@ -351,6 +400,7 @@ class Detrended(Krige):
             exact=exact,
             cond_err=cond_err,
             pseudo_inv=pseudo_inv,
+            pseudo_inv_type=pseudo_inv_type,
         )
 
 

--- a/gstools/krige/methods.py
+++ b/gstools/krige/methods.py
@@ -58,13 +58,15 @@ class Simple(Krige):
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: True
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`int` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `1`: use `pinv` from `scipy` which uses `lstsq`
             * `2`: use `pinv2` from `scipy` which uses `SVD`
             * `3`: use `pinvh` from `scipy` which uses eigen-values
 
+        If you want to use another routine to invert the kriging matrix,
+        you can pass a callable which takes a matrix and returns the inverse.
         Default: `1`
     """
 
@@ -131,13 +133,15 @@ class Ordinary(Krige):
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: True
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`int` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `1`: use `pinv` from `scipy` which uses `lstsq`
             * `2`: use `pinv2` from `scipy` which uses `SVD`
             * `3`: use `pinvh` from `scipy` which uses eigen-values
 
+        If you want to use another routine to invert the kriging matrix,
+        you can pass a callable which takes a matrix and returns the inverse.
         Default: `1`
     """
 
@@ -214,13 +218,15 @@ class Universal(Krige):
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: True
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`int` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `1`: use `pinv` from `scipy` which uses `lstsq`
             * `2`: use `pinv2` from `scipy` which uses `SVD`
             * `3`: use `pinvh` from `scipy` which uses eigen-values
 
+        If you want to use another routine to invert the kriging matrix,
+        you can pass a callable which takes a matrix and returns the inverse.
         Default: `1`
     """
 
@@ -294,13 +300,15 @@ class ExtDrift(Krige):
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: True
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`int` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `1`: use `pinv` from `scipy` which uses `lstsq`
             * `2`: use `pinv2` from `scipy` which uses `SVD`
             * `3`: use `pinvh` from `scipy` which uses eigen-values
 
+        If you want to use another routine to invert the kriging matrix,
+        you can pass a callable which takes a matrix and returns the inverse.
         Default: `1`
     """
 
@@ -370,13 +378,15 @@ class Detrended(Krige):
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: True
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`int` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `1`: use `pinv` from `scipy` which uses `lstsq`
             * `2`: use `pinv2` from `scipy` which uses `SVD`
             * `3`: use `pinvh` from `scipy` which uses eigen-values
 
+        If you want to use another routine to invert the kriging matrix,
+        you can pass a callable which takes a matrix and returns the inverse.
         Default: `1`
     """
 

--- a/gstools/tools/__init__.py
+++ b/gstools/tools/__init__.py
@@ -19,6 +19,7 @@ Special functions
 ^^^^^^^^^^^^^^^^^
 
 .. autosummary::
+   confidence_scaling
    inc_gamma
    exp_int
    inc_beta
@@ -49,6 +50,7 @@ from gstools.tools.export import (
 )
 
 from gstools.tools.special import (
+    confidence_scaling,
     inc_gamma,
     exp_int,
     inc_beta,
@@ -66,6 +68,7 @@ __all__ = [
     "to_vtk",
     "to_vtk_structured",
     "to_vtk_unstructured",
+    "confidence_scaling",
     "inc_gamma",
     "exp_int",
     "inc_beta",

--- a/gstools/tools/special.py
+++ b/gstools/tools/special.py
@@ -20,6 +20,7 @@ import numpy as np
 from scipy import special as sps
 
 __all__ = [
+    "confidence_scaling",
     "inc_gamma",
     "exp_int",
     "inc_beta",
@@ -32,8 +33,25 @@ __all__ = [
 # special functions ###########################################################
 
 
+def confidence_scaling(per=0.95):
+    """
+    Scaling of standard deviation to get the desired confidence interval.
+
+    Parameters
+    ----------
+    per : :class:`float`, optional
+        Confidence level. The default is 0.95.
+
+    Returns
+    -------
+    :class:`float`
+        Scale to multiply the standard deviation with.
+    """
+    return np.sqrt(2) * sps.erfinv(per)
+
+
 def inc_gamma(s, x):
-    r"""The (upper) incomplete gamma function.
+    r"""Calculate the (upper) incomplete gamma function.
 
     Given by: :math:`\Gamma(s,x) = \int_x^{\infty} t^{s-1}\,e^{-t}\,{\rm d}t`
 
@@ -54,7 +72,7 @@ def inc_gamma(s, x):
 
 
 def exp_int(s, x):
-    r"""The exponential integral :math:`E_s(x)`.
+    r"""Calculate the exponential integral :math:`E_s(x)`.
 
     Given by: :math:`E_s(x) = \int_1^\infty \frac{e^{-xt}}{t^s}\,\mathrm dt`
 
@@ -90,7 +108,7 @@ def exp_int(s, x):
 
 
 def inc_beta(a, b, x):
-    r"""The incomplete Beta function.
+    r"""Calculate the incomplete Beta function.
 
     Given by: :math:`B(a,b;\,x) = \int_0^x t^{a-1}\,(1-t)^{b-1}\,dt`
 
@@ -107,7 +125,7 @@ def inc_beta(a, b, x):
 
 
 def tplstable_cor(r, len_scale, hurst, alpha):
-    r"""The correlation function of the TPLStable model.
+    r"""Calculate the correlation function of the TPLStable model.
 
     Given by the following correlation function:
 


### PR DESCRIPTION
Closes #79 
Fixes #89 

Here comes the great unification of our `krige` submodule:

- [x] Swiss Army Knife for kriging: The `Krige` class now provides everything in one place
- [x] "Kriging the mean" is now possible with the switch `only_mean` in the call routine
- [x] `Simple`/`Ordinary`/`Universal`/`ExtDrift`/`Detrended` are only shortcuts to `Krige` with limited input parameter list
- [x] We now use the `covariance` function to build up the kriging matrix
- [x] An `unbiased` switch was added to enable simple kriging (where the unbiased condition is not given)
- [x] An `exact` switch was added to allow smother results, if a `nugget` is present in the model
- [x] An `cond_err` parameter was added, where measurement error variances can be given for each conditional point
- [x] pseudo-inverse matrix is now used to solve the kriging system (can be disabled by the new switch `pseudo_inv`), this is equal to solving the system with least-squares and prevents numerical errors
- [x] New examples added
- [x] New tests added

PS: I needed to create a new PR, since there were some commits in the branch, that weren't recognized by the last PR.