### PR TITLE
Geo variogram

### DIFF
--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -36,7 +36,7 @@ def _set_distance(distance):
     """Translate the verbose Python distance identifier to single char."""
     if distance.lower() == "euclidean":
         cython_distance = "e"
-    elif distance.lower() == "spherical":
+    elif distance.lower() == "great-circle":
         cython_distance = "s"
     else:
         raise ValueError(
@@ -109,7 +109,7 @@ def vario_estimate_unstructured(
         the distance function, possible choices:
 
             * "euclidean": the distance in Euclidean spaces
-            * "spherical": the great-circle distance on spheres
+            * "great-circle": the great-circle distance on spheres
 
         Default: "euclidean"
 

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -32,6 +32,18 @@ def _set_estimator(estimator):
         )
     return cython_estimator
 
+def _set_distance(distance):
+    """Translate the verbose Python distance identifier to single char."""
+    if distance.lower() == "euclidean":
+        cython_distance = "e"
+    elif distance.lower() == "spherical":
+        cython_distance = "s"
+    else:
+        raise ValueError(
+            "Unknown variogram distance function " + str(distance)
+        )
+    return cython_distance
+
 
 def vario_estimate_unstructured(
     pos,
@@ -40,6 +52,7 @@ def vario_estimate_unstructured(
     sampling_size=None,
     sampling_seed=None,
     estimator="matheron",
+    distance="euclidean",
 ):
     r"""
     Estimates the variogram on a unstructured grid.
@@ -92,6 +105,13 @@ def vario_estimate_unstructured(
             * "cressie": an estimator more robust to outliers
 
         Default: "matheron"
+    distance : :class:`str`, optional
+        the distance function, possible choices:
+
+            * "euclidean": the distance in Euclidean spaces
+            * "spherical": the great-circle distance on spheres
+
+        Default: "euclidean"
 
     Returns
     -------
@@ -116,11 +136,18 @@ def vario_estimate_unstructured(
             z = z[sampled_idx]
 
     cython_estimator = _set_estimator(estimator)
+    cython_distance = _set_distance(distance)
 
     return (
         bin_centres,
         unstructured(
-            field, bin_edges, x, y, z, estimator_type=cython_estimator
+            field,
+            bin_edges,
+            x,
+            y,
+            z,
+            estimator_type=cython_estimator,
+            distance_type=cython_distance,
         ),
     )
 

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -187,7 +187,7 @@ class TestVariogramUnstructured(unittest.TestCase):
         lat = np.array((38.725267, 0.313611, 31.205167))
         lon = np.array((-9.150019, 32.581111, -7.862263))
         d = np.array((2, 1200, 2570))
-        bins = np.array((0.0, 844_999.0, 6_021_999.0, 10_000_000.0))
+        bins = np.array((0.0, 844999.0, 6021999.0, 10000000.0))
         _, gamma = vario_estimate_unstructured((lat, lon), d, bins, distance='spherical')
         self.assertAlmostEqual(gamma[0], 3297312.)
         self.assertAlmostEqual(gamma[1], 828026.)

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -183,6 +183,15 @@ class TestVariogramUnstructured(unittest.TestCase):
         self.assertAlmostEqual(gamma[len(gamma) // 2], var, places=2)
         self.assertAlmostEqual(gamma[-1], var, places=2)
 
+    def test_spherical_dist(self):
+        lat = np.array((38.725267, 0.313611, 31.205167))
+        lon = np.array((-9.150019, 32.581111, -7.862263))
+        d = np.array((2, 1200, 2570))
+        bins = np.array((0.0, 844_999.0, 6_021_999.0, 10_000_000.0))
+        _, gamma = vario_estimate_unstructured((lat, lon), d, bins, distance='spherical')
+        self.assertAlmostEqual(gamma[0], 3297312.)
+        self.assertAlmostEqual(gamma[1], 828026.)
+
     def test_assertions(self):
         x = np.arange(0, 10)
         x_e = np.arange(0, 11)

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -188,7 +188,7 @@ class TestVariogramUnstructured(unittest.TestCase):
         lon = np.array((-9.150019, 32.581111, -7.862263))
         d = np.array((2, 1200, 2570))
         bins = np.array((0.0, 844999.0, 6021999.0, 10000000.0))
-        _, gamma = vario_estimate_unstructured((lat, lon), d, bins, distance='spherical')
+        _, gamma = vario_estimate_unstructured((lat, lon), d, bins, distance='great-circle')
         self.assertAlmostEqual(gamma[0], 3297312.)
         self.assertAlmostEqual(gamma[1], 828026.)
 


### PR DESCRIPTION
A first step towards supporting spherical coordinate systems #54 is to support variogram estimation on spherical coordinate systems.

This is a first proposal for calculating unstructured variograms on spheres.

A few things to discuss:

- [x] is `spherical` a good name for the argument in the function `vario_estimate_unstructured`?
  - let's use `great-circle`
- [ ] how are we going to provide the new distance function to users? - This is important in order to, e.g. create bins.
  - Possible options:
    - import the Cython function from `estimator.pyx` into one of the `tools.py` namespaces
    - create a new `tools.pyx` as a more general Cython code collection
    - reimplement the distance function in Python
    - use on of the already existing Python packages as external dependenies, e.g. [haversine](https://github.com/mapado/haversine)
  - Suggestion:
    - [ ] users shouldn't need to care about the haversine routines (just use it internally)
    - [ ] the rest of GSTools should deal with xyz positions converted by a new routine `latlon2xyz`
    - [ ] variogram fitting needs to provide a new workflow to fit associated 3D *Yadrenko* models to estimated great-circle variograms
    - [ ] with all this, we don't need to rewrite the `SRF`, `CovModel` and `Krige` classes
    - [ ] we need a set of good tutorials dealing with geo-coordinates (explaining yadrenko models and great-circle distances)
- [ ] better testing: I'm not sure what else to test
- [ ] how could potential pitfalls / confusing arguments be caught (lat-lon, y-x)
  - as written above: conversions routines and good tutorials
- [ ] should we stick to the unit of metre or does kilometre make more sense?
  - we shoud use the great-circle distance in `deg` and leave this decision to the user