### PR TITLE
Isotropic rotation not possible

### DIFF
--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -1220,7 +1220,7 @@ class CovModel(metaclass=InitSubclassMeta):
     def do_rotation(self):
         """:any:`bool`: State if a rotation is performed."""
         return (
-            not np.all(np.isclose(self.angles, 0.0)) and not self.is_isotropic
+            not np.all(np.isclose(self.angles, 0.0))
         )
 
     @property


### PR DESCRIPTION
I just wanted to make a pretty plot of a 3d field and instead of rotating the camera, I wanted to simply rotate the field.
This is not possible if the field is isotropic.

Of course, from a stochastic point of view, it doesn't make sense to rotate a field, if it is isotropic. But this is a restriction, which is not necessary, especially if one is working with a single realisation.

Especially for nice plotting, I suggest to simply remove the check for isotropicity, as seen in the diff.