### PR TITLE
Variogram estimation from multiple fields

### DIFF
--- a/examples/03_variogram/03_multi_vario.py
+++ b/examples/03_variogram/03_multi_vario.py
@@ -20,6 +20,7 @@ srf = gs.SRF(model, mean=0)
 
 field1 = srf((x, y), seed=19970221)
 field2 = srf((x, y), seed=20011012)
+fields = [field1, field2]
 
 ###############################################################################
 # Now we estimate the variograms for both fields individual and then again
@@ -28,7 +29,7 @@ field2 = srf((x, y), seed=20011012)
 bins = np.arange(40)
 bin_center, gamma1 = gs.vario_estimate_unstructured((x, y), field1, bins)
 bin_center, gamma2 = gs.vario_estimate_unstructured((x, y), field2, bins)
-bin_center, gamma = gs.vario_estimate_unstructured((x, y), [field1, field2], bins)
+bin_center, gamma = gs.vario_estimate_unstructured((x, y), fields, bins)
 
 ###############################################################################
 # Now we demonstrate, that the mean variogram from both fields coincides
@@ -37,6 +38,6 @@ bin_center, gamma = gs.vario_estimate_unstructured((x, y), [field1, field2], bin
 plt.plot(bin_center, gamma1, label="field 1")
 plt.plot(bin_center, gamma2, label="field 2")
 plt.plot(bin_center, gamma, label="field joint")
-plt.plot(bin_center, 0.5*(gamma1+gamma2), ":", label="field 1+2 mean")
+plt.plot(bin_center, 0.5 * (gamma1 + gamma2), ":", label="field 1+2 mean")
 plt.legend()
 plt.show()

--- a/examples/03_variogram/03_multi_vario.py
+++ b/examples/03_variogram/03_multi_vario.py
@@ -1,0 +1,42 @@
+"""
+Multi-field variogram estimation
+--------------------------------
+
+In this example, we demonstrate how to estimate a variogram from multiple
+fields at the same point-set, that should have the same statistical properties.
+"""
+import numpy as np
+import gstools as gs
+import matplotlib.pyplot as plt
+
+
+x = np.random.RandomState(19970221).rand(1000) * 100.0
+y = np.random.RandomState(20011012).rand(1000) * 100.0
+model = gs.Exponential(dim=2, var=2, len_scale=8)
+srf = gs.SRF(model, mean=0)
+
+###############################################################################
+# Generate two synthetic fields with an exponential model.
+
+field1 = srf((x, y), seed=19970221)
+field2 = srf((x, y), seed=20011012)
+
+###############################################################################
+# Now we estimate the variograms for both fields individual and then again
+# simultaneously with only one call.
+
+bins = np.arange(40)
+bin_center, gamma1 = gs.vario_estimate_unstructured((x, y), field1, bins)
+bin_center, gamma2 = gs.vario_estimate_unstructured((x, y), field2, bins)
+bin_center, gamma = gs.vario_estimate_unstructured((x, y), [field1, field2], bins)
+
+###############################################################################
+# Now we demonstrate, that the mean variogram from both fields coincides
+# with the joined estimated one.
+
+plt.plot(bin_center, gamma1, label="field 1")
+plt.plot(bin_center, gamma2, label="field 2")
+plt.plot(bin_center, gamma, label="field joint")
+plt.plot(bin_center, 0.5*(gamma1+gamma2), ":", label="field 1+2 mean")
+plt.legend()
+plt.show()

--- a/gstools/variogram/estimator.pyx
+++ b/gstools/variogram/estimator.pyx
@@ -162,10 +162,10 @@ def unstructured(
                 dist = distance(x, y, z, k, j)
                 if dist >= bin_edges[i] and dist < bin_edges[i+1]:
                     for m in range(f_max):
-                        if isnan(f[m,k]) or isnan(f[m,j]):
-                            continue # skip no data values
-                        counts[i] += 1
-                        variogram[i] += estimator_func(f[m,k] - f[m,j])
+                        # skip no data values
+                        if not (isnan(f[m,k]) or isnan(f[m,j])):
+                            counts[i] += 1
+                            variogram[i] += estimator_func(f[m,k] - f[m,j])
 
     normalization_func(variogram, counts)
     return np.asarray(variogram)

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -116,9 +116,9 @@ def vario_estimate_unstructured(
     if not np.isnan(no_data):
         field[field == float(no_data)] = np.nan
 
-    if sampling_size is not None and sampling_size < len(field):
+    if sampling_size is not None and sampling_size < len(x):
         sampled_idx = np.random.RandomState(sampling_seed).choice(
-            np.arange(len(field)), sampling_size, replace=False
+            np.arange(len(x)), sampling_size, replace=False
         )
         field = field[:, sampled_idx]
         x = x[sampled_idx]

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -105,12 +105,18 @@ def vario_estimate_unstructured(
     :class:`tuple` of :class:`numpy.ndarray`
         the estimated variogram and the bin centers
     """
-    # TODO check_mesh
     # allow multiple fields at same positions (ndmin=2: first axis -> field ID)
     field = np.array(field, ndmin=2, dtype=np.double)
     bin_edges = np.array(bin_edges, ndmin=1, dtype=np.double)
     x, y, z, dim = pos2xyz(pos, calc_dim=True, dtype=np.double)
     bin_centres = (bin_edges[:-1] + bin_edges[1:]) / 2.0
+
+    # check_mesh
+    if len(field.shape) > 2 or field.shape[1] != len(x):
+        try:
+            field = field.reshape((-1, len(x)))
+        except ValueError:
+            raise ValueError("'field' has wrong shape")
 
     # set no_data values
     if not np.isnan(no_data):

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -120,7 +120,7 @@ def vario_estimate_unstructured(
         sampled_idx = np.random.RandomState(sampling_seed).choice(
             np.arange(len(field)), sampling_size, replace=False
         )
-        field = field[sampled_idx]
+        field = field[:, sampled_idx]
         x = x[sampled_idx]
         if dim > 1:
             y = y[sampled_idx]

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -220,24 +220,31 @@ class TestVariogramUnstructured(unittest.TestCase):
 
     def test_multi_field(self):
         x = np.random.RandomState(19970221).rand(100) * 100.0
-        y = np.random.RandomState(20011012).rand(100) * 100.0
         model = gs.Exponential(dim=1, var=2, len_scale=10)
         srf = gs.SRF(model)
-        field1 = srf((x, y), seed=19970221)
-        field2 = srf((x, y), seed=20011012)
+        field1 = srf(x, seed=19970221)
+        field2 = srf(x, seed=20011012)
         bins = np.arange(20) * 2
-        bin_center, gamma1 = gs.vario_estimate_unstructured(
-            (x, y), field1, bins
-        )
-        bin_center, gamma2 = gs.vario_estimate_unstructured(
-            (x, y), field2, bins
-        )
+        bin_center, gamma1 = gs.vario_estimate_unstructured(x, field1, bins)
+        bin_center, gamma2 = gs.vario_estimate_unstructured(x, field2, bins)
         bin_center, gamma = gs.vario_estimate_unstructured(
-            (x, y), [field1, field2], bins
+            x, [field1, field2], bins
         )
         gamma_mean = 0.5 * (gamma1 + gamma2)
         for i in range(len(gamma)):
             self.assertAlmostEqual(gamma[i], gamma_mean[i], places=2)
+
+    def test_no_data(self):
+        x1 = np.random.RandomState(19970221).rand(100) * 100.0
+        field1 = np.random.RandomState(20011012).rand(100) * 100.0
+        field1[:10] = np.nan
+        x2 = x1[10:]
+        field2 = field1[10:]
+        bins = np.arange(20) * 2
+        bin_center, gamma1 = gs.vario_estimate_unstructured(x1, field1, bins)
+        bin_center, gamma2 = gs.vario_estimate_unstructured(x2, field2, bins)
+        for i in range(len(gamma1)):
+            self.assertAlmostEqual(gamma1[i], gamma2[i], places=2)
 
 
 if __name__ == "__main__":

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -5,6 +5,7 @@ This is a unittest of the variogram module.
 
 import unittest
 import numpy as np
+import gstools as gs
 from gstools import vario_estimate_unstructured
 
 
@@ -216,6 +217,27 @@ class TestVariogramUnstructured(unittest.TestCase):
         self.assertRaises(
             ValueError, vario_estimate_unstructured, [x], field_e, bins
         )
+
+    def test_multi_field(self):
+        x = np.random.RandomState(19970221).rand(100) * 100.0
+        y = np.random.RandomState(20011012).rand(100) * 100.0
+        model = gs.Exponential(dim=1, var=2, len_scale=10)
+        srf = gs.SRF(model)
+        field1 = srf((x, y), seed=19970221)
+        field2 = srf((x, y), seed=20011012)
+        bins = np.arange(20) * 2
+        bin_center, gamma1 = gs.vario_estimate_unstructured(
+            (x, y), field1, bins
+        )
+        bin_center, gamma2 = gs.vario_estimate_unstructured(
+            (x, y), field2, bins
+        )
+        bin_center, gamma = gs.vario_estimate_unstructured(
+            (x, y), [field1, field2], bins
+        )
+        gamma_mean = 0.5 * (gamma1 + gamma2)
+        for i in range(20):
+            self.assertAlmostEqual(gamma[i], gamma_mean[i], places=2)
 
 
 if __name__ == "__main__":

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -236,7 +236,7 @@ class TestVariogramUnstructured(unittest.TestCase):
             (x, y), [field1, field2], bins
         )
         gamma_mean = 0.5 * (gamma1 + gamma2)
-        for i in range(20):
+        for i in range(len(gamma)):
             self.assertAlmostEqual(gamma[i], gamma_mean[i], places=2)
 
 


### PR DESCRIPTION
With this PR a new option for unstructured variogram estimation is added:
You can now estimate one variogram from multiple fields on the same point-set. This could be useful to estimate a single variogram to describe multiple realizations of the same process.

Example:
- time series of precipitation data -> one variogram for all days needed

In addition, these fields can have missing values, denoted by a new `no_data` argument.

Checklist:
- [x] blackened
- [x] test written
- [x] examples added