### PR TITLE
CI update: provide Python 3.9 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     fi
 
 script:
-  - python3 -m pip install cibuildwheel==1.3.0
+  - python3 -m pip install cibuildwheel==1.6.4
   - python3 -m cibuildwheel --output-dir dist
 
 after_success:
@@ -56,9 +56,6 @@ jobs:
         - python3 -m pytest --cov gstools --cov-report term-missing -v tests/
         - python3 -m coveralls
 
-    - name: "Linux py35"
-      services: docker
-      env: CIBW_BUILD="cp35-*"
     - name: "Linux py36"
       services: docker
       env: CIBW_BUILD="cp36-*"
@@ -68,11 +65,10 @@ jobs:
     - name: "Linux py38"
       services: docker
       env: CIBW_BUILD="cp38-*"
+    - name: "Linux py39"
+      services: docker
+      env: CIBW_BUILD="cp39-*"
 
-    - name: "MacOS py35"
-      os: osx
-      language: shell
-      env: CIBW_BUILD="cp35-*"
     - name: "MacOS py36"
       os: osx
       language: shell
@@ -85,11 +81,11 @@ jobs:
       os: osx
       language: shell
       env: CIBW_BUILD="cp38-*"
-
-    - name: "Win py35"
-      os: windows
+    - name: "MacOS py39"
+      os: osx
       language: shell
-      env: CIBW_BUILD="cp35-*"
+      env: CIBW_BUILD="cp39-*"
+
     - name: "Win py36"
       os: windows
       language: shell
@@ -102,3 +98,7 @@ jobs:
       os: windows
       language: shell
       env: CIBW_BUILD="cp38-*"
+    - name: "Win py39"
+      os: windows
+      language: shell
+      env: CIBW_BUILD="cp39-*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 
 after_success:
   - |
-    if [[ $TRAVIS_PULL_REQUEST == "false" -a \( $TRAVIS_BRANCH == "master" -o $TRAVIS_BRANCH == "develop" \)]]; then
+    if [[ $TRAVIS_PULL_REQUEST == "false" && ( $TRAVIS_BRANCH == "master" || $TRAVIS_BRANCH == "develop" ) ]]; then
       python3 -m pip install twine
       python3 -m twine upload --verbose --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,14 @@ script:
 
 after_success:
   - |
-    if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then
+    if [[ $TRAVIS_PULL_REQUEST == "false" -a \( $TRAVIS_BRANCH == "master" -o $TRAVIS_BRANCH == "develop" \)]]; then
       python3 -m pip install twine
       python3 -m twine upload --verbose --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
-      if [[ $TRAVIS_TAG ]]; then python3 -m twine upload --verbose --skip-existing dist/*; fi
+    fi
+  - |
+    if [[ $TRAVIS_TAG ]]; then
+      python3 -m pip install twine
+      python3 -m twine upload --verbose --skip-existing dist/*
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ jobs:
         - python3 -m pytest --cov gstools --cov-report term-missing -v tests/
         - python3 -m coveralls
 
+    - name: "Linux py35"
+      services: docker
+      env: CIBW_BUILD="cp35-*"
     - name: "Linux py36"
       services: docker
       env: CIBW_BUILD="cp36-*"
@@ -69,6 +72,10 @@ jobs:
       services: docker
       env: CIBW_BUILD="cp39-*"
 
+    - name: "MacOS py35"
+      os: osx
+      language: shell
+      env: CIBW_BUILD="cp35-*"
     - name: "MacOS py36"
       os: osx
       language: shell
@@ -86,6 +93,10 @@ jobs:
       language: shell
       env: CIBW_BUILD="cp39-*"
 
+    - name: "Win py35"
+      os: windows
+      language: shell
+      env: CIBW_BUILD="cp35-*"
     - name: "Win py36"
       os: windows
       language: shell

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -1219,9 +1219,7 @@ class CovModel(metaclass=InitSubclassMeta):
     @property
     def do_rotation(self):
         """:any:`bool`: State if a rotation is performed."""
-        return (
-            not np.all(np.isclose(self.angles, 0.0))
-        )
+        return not np.all(np.isclose(self.angles, 0.0))
 
     @property
     def is_isotropic(self):

--- a/gstools/krige/base.py
+++ b/gstools/krige/base.py
@@ -511,13 +511,13 @@ class Krige(Field):
     @property
     def cond_err(self):
         """:class:`list`: The measurement errors at the condition points."""
-        if self._cond_err == "nugget":
+        if isinstance(self._cond_err, str) and self._cond_err == "nugget":
             return self.model.nugget
         return self._cond_err
 
     @cond_err.setter
     def cond_err(self, value):
-        if value == "nugget":
+        if isinstance(value, str) and value == "nugget":
             self._cond_err = value
         else:
             if self.exact:
@@ -634,7 +634,9 @@ class Krige(Field):
         """Return String representation."""
         return (
             "{0}(model={1}, cond_no={2}".format(
-                self.name, self.model.name, self.cond_no,
+                self.name,
+                self.model.name,
+                self.cond_no,
             )
             + ")"
         )

--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Utilities",


### PR DESCRIPTION
This PR introduces wheels for Python 3.9.

In addition, pushes to `test.pypi.org` are now only done for pushes to `master` or `develop`.

Also a `FutureWarning` from numpy for element wise comparison of arrays is fixed.