### PR TITLE
CovModel.fit: check if weights are given as a string to prevent numpy comparison errors in the future

### DIFF
--- a/gstools/covmodel/fit.py
+++ b/gstools/covmodel/fit.py
@@ -293,7 +293,7 @@ def _set_weights(model, weights, x_data, curve_fit_kwargs, is_dir_vario):
     if weights is not None:
         if callable(weights):
             weights = 1.0 / weights(x_data)
-        elif weights == "inv":
+        elif isinstance(weights, str) and weights == "inv":
             weights = 1.0 + x_data
         elif is_dir_vario:
             if weights.size * model.dim == x_data.size:


### PR DESCRIPTION
In case `weights` are given as numpy array, we need to prevent comparison to a string.