### PR TITLE
CI: The sdists should only be uploaded once to the artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,6 @@ jobs:
           python -m cibuildwheel --output-dir dist
 
       - uses: actions/upload-artifact@v2
-        if: ${{ matrix.python-version }} == '3.9'
         with:
           path: ./dist/*.whl
 
@@ -91,8 +90,8 @@ jobs:
           python -m coveralls
 
       - uses: actions/upload-artifact@v2
+        if: ${{ matrix.python-version }} == '3.9' && ${{ matrix.os }} == 'ubuntu-latest'
         with:
-          python-version: 3.9
           path: dist/*.tar.gz
 
   upload_to_pypi:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ env:
 
 jobs:
   build_wheels:
-    name: wheels on ${{matrix.os}}
-    runs-on: ${{matrix.os}}
+    name: wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,8 +53,8 @@ jobs:
           path: ./dist/*.whl
 
   build_sdist:
-    name: sdist on ${{matrix.os}} with py ${{ matrix.python-version }}
-    runs-on: ${{matrix.os}}
+    name: sdist on ${{ matrix.os }} with py ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
+          python-version: 3.9
           path: dist/*.tar.gz
 
   upload_to_pypi:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
           python -m coveralls
 
       - uses: actions/upload-artifact@v2
-        if: ${{ matrix.python-version }} == 3.9 && ${{ matrix.os }} == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
         with:
           path: dist/*.tar.gz
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
           python -m coveralls
 
       - uses: actions/upload-artifact@v2
-        if: ${{ matrix.python-version }} == '3.9' && ${{ matrix.os }} == 'ubuntu-latest'
+        if: ${{ matrix.python-version }} == 3.9 && ${{ matrix.os }} == 'ubuntu-latest'
         with:
           path: dist/*.tar.gz
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
 
       - uses: actions/upload-artifact@v2
+        if: python-version == '3.9'
         with:
           path: ./dist/*.whl
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
 
       - uses: actions/upload-artifact@v2
-        if: python-version == '3.9'
+        if: ${{ matrix.python-version }} == '3.9'
         with:
           path: ./dist/*.whl
 


### PR DESCRIPTION
The `build_sdist` job in the actions script uploads the artifact for every Python version. Often this works without problems, but sometimes it comes to errors and the artifact is not created.
The reason why I keep the sdist creation with all Python versions is to test GSTools without OpenMP support.

This PR is a draft, but the only way to kick off the actions.