### PR TITLE
Coveralls 3.0 bugfix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest --cov gstools --cov-report term-missing -v tests/
-          python -m coveralls
+          python -m coveralls --service=github
 
       - uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
           pip install -r requirements_setup.txt
           pip install -r requirements.txt
           pip install -r requirements_test.txt
-          pip install coveralls>=2.0.0
+          pip install coveralls>=3.0.0
 
       - name: Build sdist
         run: |


### PR DESCRIPTION
coveralls-python 3.0 broke our GH-Actions workflow.
See: https://github.com/coveralls-clients/coveralls-python/issues/251