### PR TITLE
Replace pyvista 3d plot with matplotlib animation in Precip example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The documentation also includes some [tutorials][tut_link], showing the most imp
 - [Conditioned random field generation][tut6_link]
 - [Field transformations][tut7_link]
 - [Geographic Coordinates][tut8_link]
+- [Spatio-Temporal Modelling][tut9_link]
 - [Miscellaneous examples][tut0_link]
 
 The associated python scripts are provided in the `examples` folder.
@@ -361,6 +362,7 @@ You can contact us via <info@geostat-framework.org>.
 [tut6_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/stable/examples/06_conditioned_fields/index.html
 [tut7_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/stable/examples/07_transformations/index.html
 [tut8_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/stable/examples/08_geo_coordinates/index.html
+[tut9_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/stable/examples/09_spatio_temporal/index.html
 [tut0_link]: https://geostat-framework.readthedocs.io/projects/gstools/en/stable/examples/00_misc/index.html
 [cor_link]: https://en.wikipedia.org/wiki/Autocovariance#Normalization
 [vtk_link]: https://www.vtk.org/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -279,6 +279,7 @@ sphinx_gallery_conf = {
         "../../examples/06_conditioned_fields/",
         "../../examples/07_transformations/",
         "../../examples/08_geo_coordinates/",
+        "../../examples/09_spatio_temporal/",
     ],
     # path where to save gallery generated examples
     "gallery_dirs": [
@@ -291,6 +292,7 @@ sphinx_gallery_conf = {
         "examples/06_conditioned_fields/",
         "examples/07_transformations/",
         "examples/08_geo_coordinates/",
+        "examples/09_spatio_temporal/",
     ],
     # Pattern to search for example files
     "filename_pattern": r"\.py",
@@ -302,6 +304,7 @@ sphinx_gallery_conf = {
     "backreferences_dir": None,
     # Modules for which function level galleries are created.  In
     "doc_module": "gstools",
+    "matplotlib_animations": True,
     # "image_scrapers": ('pyvista', 'matplotlib'),
     # "first_notebook_cell": ("%matplotlib inline\n"
     #                         "from pyvista import set_plot_theme\n"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,6 +98,7 @@ showing the most important use cases of GSTools, which are
 - `Conditioned random field generation <examples/06_conditioned_fields/index.html>`__
 - `Field transformations <examples/07_transformations/index.html>`__
 - `Geographic Coordinates <examples/08_geo_coordinates/index.html>`__
+- `Spatio-Temporal Modelling <examples/09_spatio_temporal/index.html>`__
 - `Miscellaneous examples <examples/00_misc/index.html>`__
 
 Some more examples are provided in the examples folder.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -20,4 +20,5 @@ explore its whole beauty and power.
    examples/06_conditioned_fields/index
    examples/07_transformations/index
    examples/08_geo_coordinates/index
+   examples/09_spatio_temporal/index
    examples/00_misc/index

--- a/examples/00_misc/03_precipitation.py
+++ b/examples/00_misc/03_precipitation.py
@@ -15,6 +15,7 @@ series.
 import copy
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.animation as ani
 import gstools as gs
 
 # fix the seed for reproducibility
@@ -149,9 +150,17 @@ amount = 3.0
 srf.field *= amount
 
 ###############################################################################
-# plot the 2d precipitation field together with the time axis as a 3d plot.
-# We will cut out the volumes with low precipitation in order to have a look
-# inside the cuboid.
+# plot the 2d precipitation field over time as an animation.
 
-mesh = srf.to_pyvista()
-mesh.threshold_percent(0.25).plot()
+def _update_ani(idx):
+    quad.set_array(srf.field[idx, :, :].T.ravel())
+    return quad,
+
+fig, ax = plt.subplots()
+quad = ax.pcolormesh(x, y, srf.field[0,:,:].T, cmap="Blues", shading="gouraud")
+cbar = fig.colorbar(quad)
+cbar.ax.set_ylabel(r"Precipitation $P$ / mm")
+ax.set_xlabel(r"$x$ / km")
+ax.set_ylabel(r"$y$ / km")
+
+ani = ani.FuncAnimation(fig, _update_ani, len(t), interval=100, blit=True)

--- a/examples/09_spatio_temporal/01_precip_1d.py
+++ b/examples/09_spatio_temporal/01_precip_1d.py
@@ -58,8 +58,9 @@ P_cut[P_cut <= threshold] = 0.0
 # account for the skewness of precipitation fields. Different values have been
 # suggested for the transformation parameter lambda, but we will stick to 1/2.
 # As already mentioned, we will perform the cutoff for the dry periods with
-# this transformation implicitly with the shift. We call the resulting field
-# Gaussian anamorphosis.
+# this transformation implicitly with the shift. The warning will tell you
+# that values have indeed been cut off and it can be ignored. We call the
+# resulting field Gaussian anamorphosis.
 
 # the lower this value, the more will be cut off, a value of 0.2 cuts off
 # nearly everything in this example.

--- a/examples/09_spatio_temporal/01_precip_1d.py
+++ b/examples/09_spatio_temporal/01_precip_1d.py
@@ -41,37 +41,46 @@ srf.structured(pos + time)
 P_gau = copy.deepcopy(srf.field)
 
 ###############################################################################
-# Now we should take care of the dry periods. Therefore we simply introduce a
-# lower threshold value.
+# Next, we could take care of the dry periods. Therefore we would simply
+# introduce a lower threshold value. But we will combine this step with the
+# next one. Anyway, for demonstration purposes, we will also do it with the
+# threshold value now.
 
-threshold = 0.7
-srf.field[srf.field <= threshold] = 0.0
-P_cut = srf.field
+threshold = 0.85
+P_cut = copy.deepcopy(srf.field)
+P_cut[P_cut <= threshold] = 0.0
 
 ###############################################################################
 # With the above lines of code we have created a cut off Gaussian spatial
 # random field with an exponential variogram. But precipitation fields are not
-# distributed Gaussian. Thus, we will now transform the field with a box-cox
-# transformation, which is often used to account for the skewness of
-# precipitation fields. Different values have been suggested for the
-# transformation parameter lambda, but we will stick to 1/2. We call the
-# resulting field Gaussian anamorphosis.
+# distributed Gaussian. Thus, we will now transform the field with an inverse
+# box-cox transformation (create a non-Gaussian field) , which is often used to
+# account for the skewness of precipitation fields. Different values have been
+# suggested for the transformation parameter lambda, but we will stick to 1/2.
+# As already mentioned, we will perform the cutoff for the dry periods with
+# this transformation implicitly with the shift. We call the resulting field
+# Gaussian anamorphosis.
 
-gs.transform.boxcox(srf, lmbda=0.5, shift=-1.0)
+# the lower this value, the more will be cut off, a value of 0.2 cuts off
+# nearly everything in this example.
+cutoff = 0.55
+gs.transform.boxcox(srf, lmbda=0.5, shift=-1.0 / cutoff)
 
 ###############################################################################
 # As a last step, the amount of precipitation is set. This should of course be
 # calibrated towards observations (the same goes for the threshold, the
 # variance, correlation length, and so on).
 
-amount = 3.0
+amount = 2.0
 srf.field *= amount
 P_ana = srf.field
 
 ###############################################################################
-# Finally we can have a look at the fields resulting from each step. For a
-# closer look, we will examine a cross section at an arbitrary location. And
-# afterwards we will create a contour plot for visual candy.
+# Finally we can have a look at the fields resulting from each step. Note, that
+# the cutoff of the cut Gaussian only approximates the cutoff values from the
+# box-cox transformation. For a closer look, we will examine a cross section
+# at an arbitrary location. And afterwards we will create a contour plot for
+# visual candy.
 
 fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
 
@@ -96,19 +105,19 @@ plt.tight_layout()
 fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
 
 axs[0, 0].set_title("Gaussian")
-cont = axs[0, 0].contourf(t, x, P_gau, cmap="PuBu")
+cont = axs[0, 0].contourf(t, x, P_gau, cmap="PuBu", levels=10)
 cbar = fig.colorbar(cont, ax=axs[0, 0])
 cbar.ax.set_ylabel(r"$P$ / mm")
 axs[0, 0].set_ylabel(r"$x$ / km")
 
 axs[0, 1].set_title("Cut Gaussian")
-cont = axs[0, 1].contourf(t, x, P_cut, cmap="PuBu")
+cont = axs[0, 1].contourf(t, x, P_cut, cmap="PuBu", levels=10)
 cbar = fig.colorbar(cont, ax=axs[0, 1])
 cbar.ax.set_ylabel(r"$P$ / mm")
 axs[0, 1].set_xlabel(r"$t$ / d")
 
 axs[1, 0].set_title("Cut Gaussian Anamorphosis")
-cont = axs[1, 0].contourf(t, x, P_ana, cmap="PuBu")
+cont = axs[1, 0].contourf(t, x, P_ana, cmap="PuBu", levels=10)
 cbar = fig.colorbar(cont, ax=axs[1, 0])
 cbar.ax.set_ylabel(r"$P$ / mm")
 axs[1, 0].set_xlabel(r"$t$ / d")

--- a/examples/09_spatio_temporal/02_precip_2d.py
+++ b/examples/09_spatio_temporal/02_precip_2d.py
@@ -1,0 +1,74 @@
+"""
+Creating a 2D Synthetic Precipitation Field
+-------------------------------------------
+
+In this example we'll create a time series of a 2D synthetic precipitation
+field.
+
+Very similar to the previous tutorial, we'll start off by creating a Gaussian
+random field with an exponential variogram, which seems to reproduce the
+spatial correlations of precipitation fields quite well. We'll create a daily
+timeseries over a two dimensional domain of 50km x 40km. This workflow is
+suited for sub daily precipitation time series.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+import gstools as gs
+
+# fix the seed for reproducibility
+seed = 20170521
+# 1st spatial axis of 50km with a resolution of 1km
+x = np.arange(0, 50, 1.0)
+# 2nd spatial axis of 40km with a resolution of 1km
+y = np.arange(0, 40, 1.0)
+# half daily timesteps over three months
+t = np.arange(0.0, 90.0, 0.5)
+
+# total spatio-temporal dimension
+st_dim = 2 + 1
+# space-time anisotropy ratio given in units d / km
+st_anis = 0.4
+
+# an exponential variogram with a corr. lengths of 5km, 5km, and 2d
+model = gs.Exponential(dim=st_dim, var=1.0, len_scale=5.0, anis=st_anis)
+# create a spatial random field instance
+srf = gs.SRF(model, seed=seed)
+
+pos, time = [x, y], [t]
+
+# the Gaussian random field
+srf.structured(pos + time)
+
+# the dry periods
+threshold = 0.4
+srf.field[srf.field <= threshold] = 0.0
+
+# account for the skewness
+gs.transform.boxcox(srf, lmbda=0.5, shift=-1.0)
+
+# adjust the amount of precipitation
+amount = 4.0
+srf.field *= amount
+
+###############################################################################
+# plot the 2d precipitation field over time as an animation.
+
+def _update_ani(time_step):
+    im.set_array(srf.field[:, :, time_step].T)
+    return im,
+
+fig, ax = plt.subplots()
+im = ax.imshow(
+    srf.field[:,:,0].T,
+    cmap="Blues",
+    interpolation="bicubic",
+    origin="lower",
+)
+cbar = fig.colorbar(im)
+cbar.ax.set_ylabel(r"Precipitation $P$ / mm")
+ax.set_xlabel(r"$x$ / km")
+ax.set_ylabel(r"$y$ / km")
+
+ani = animation.FuncAnimation(fig, _update_ani, len(t), interval=100, blit=True)

--- a/examples/09_spatio_temporal/02_precip_2d.py
+++ b/examples/09_spatio_temporal/02_precip_2d.py
@@ -41,12 +41,9 @@ pos, time = [x, y], [t]
 # the Gaussian random field
 srf.structured(pos + time)
 
-# the dry periods
-threshold = 0.4
-srf.field[srf.field <= threshold] = 0.0
-
-# account for the skewness
-gs.transform.boxcox(srf, lmbda=0.5, shift=-1.0)
+# account for the skewness and the dry periods
+cutoff = 0.55
+gs.transform.boxcox(srf, lmbda=0.5, shift=-1.0 / cutoff)
 
 # adjust the amount of precipitation
 amount = 4.0

--- a/examples/09_spatio_temporal/README.rst
+++ b/examples/09_spatio_temporal/README.rst
@@ -1,0 +1,6 @@
+Spatio-Temporal Modeling
+========================
+
+
+Examples
+--------


### PR DESCRIPTION
I've updated the precipitation example to now show the time evolution of the 2D P-field as an animated figure.