### PR TITLE
Drop Python 3.5 support and update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  # needed by coveralls
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CIBW_BUILD: "cp35-* cp36-* cp37-* cp38-* cp39-*"
-  CIBW_BEFORE_BUILD: "pip install numpy==1.17.3 cython>=0.29.14 setuptools"
-  CIBW_TEST_REQUIRES: "pytest"
-  CIBW_TEST_COMMAND: "pytest -v {project}/tests"
-
 jobs:
   build_wheels:
     name: wheels on ${{ matrix.os }}
@@ -35,18 +27,15 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: Set up Python
-        uses: actions\setup-python@v2
-        with:
-          python-version: "3.8"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install cibuildwheel==1.7.0
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: joerick/cibuildwheel@v1.10.0
+        env:
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
+          CIBW_BEFORE_BUILD: pip install numpy==1.17.3 cython>=0.29.14 setuptools
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest -v {project}/tests
+        with:
+          output-dir: dist
 
       - uses: actions/upload-artifact@v2
         with:
@@ -59,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -85,6 +74,8 @@ jobs:
           python setup.py --openmp build_ext --inplace
 
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python -m pytest --cov gstools --cov-report term-missing -v tests/
           python -m coveralls --service=github
@@ -105,7 +96,7 @@ jobs:
           path: dist
 
       - name: Publish to Test PyPI
-        # only if working on develop
+        # only if working on master or develop
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         uses: joerick/cibuildwheel@v1.10.0
         env:
           CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
-          CIBW_BEFORE_BUILD: pip install numpy==1.17.3 cython>=0.29.14 setuptools
+          CIBW_BEFORE_BUILD: pip install numpy==1.19.* cython==0.29.* setuptools
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest -v {project}/tests
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Publish to Test PyPI
         # only if working on master or develop
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.test_pypi_password }}
@@ -108,7 +108,7 @@ jobs:
       - name: Publish to PyPI
         # only if tagged
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/gstools/__init__.py
+++ b/gstools/__init__.py
@@ -165,7 +165,7 @@ from gstools.covmodel import (
 
 try:
     from gstools._version import __version__
-except ImportError:  # pragma: nocover
+except ModuleNotFoundError:  # pragma: nocover
     # package is not installed
     __version__ = "0.0.0.dev0"
 

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -24,7 +24,6 @@ from gstools.tools.geometric import (
     pos2latlon,
 )
 from gstools.covmodel.tools import (
-    InitSubclassMeta,
     _init_subclass,
     set_opt_args,
     set_len_anis,
@@ -47,7 +46,7 @@ __all__ = ["CovModel"]
 HANKEL_DEFAULT = {"a": -1, "b": 1, "N": 200, "h": 0.001, "alt": True}
 
 
-class CovModel(metaclass=InitSubclassMeta):
+class CovModel(metaclass=type):
     r"""Base class for the GSTools covariance models.
 
     Parameters

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -46,7 +46,7 @@ __all__ = ["CovModel"]
 HANKEL_DEFAULT = {"a": -1, "b": 1, "N": 200, "h": 0.001, "alt": True}
 
 
-class CovModel(metaclass=type):
+class CovModel:
     r"""Base class for the GSTools covariance models.
 
     Parameters

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -133,7 +133,7 @@ class CovModel:
         latlon=False,
         var_raw=None,
         hankel_kw=None,
-        **opt_arg
+        **opt_arg,
     ):
         # assert, that we use a subclass
         # this is the case, if __init_subclass__ is called, which creates
@@ -210,12 +210,8 @@ class CovModel:
 
         # modify the docstrings: class docstring gets attributes added
         if cls.__doc__ is None:
-            cls.__doc__ = (
-                "User defined GSTools Covariance-Model."
-                + CovModel.__doc__[45:]
-            )
-        else:
-            cls.__doc__ += CovModel.__doc__[45:]
+            cls.__doc__ = "User defined GSTools Covariance-Model."
+        cls.__doc__ += CovModel.__doc__[45:]
         # overridden functions get standard doc if no new doc was created
         ignore = ["__", "variogram", "covariance", "cor"]
         for attr in cls.__dict__:
@@ -571,7 +567,7 @@ class CovModel:
         max_eval=None,
         return_r2=False,
         curve_fit_kwargs=None,
-        **para_select
+        **para_select,
     ):
         """
         Fiting the variogram-model to an empirical variogram.
@@ -714,7 +710,7 @@ class CovModel:
             max_eval=max_eval,
             return_r2=return_r2,
             curve_fit_kwargs=curve_fit_kwargs,
-            **para_select
+            **para_select,
         )
 
     # bounds setting and checks
@@ -771,7 +767,7 @@ class CovModel:
     def var_bounds(self, bounds):
         if not check_bounds(bounds):
             raise ValueError(
-                "Given bounds for 'var' are not valid, got: " + str(bounds)
+                f"Given bounds for 'var' are not valid, got: {bounds}"
             )
         self._var_bounds = bounds
 
@@ -791,8 +787,7 @@ class CovModel:
     def len_scale_bounds(self, bounds):
         if not check_bounds(bounds):
             raise ValueError(
-                "Given bounds for 'len_scale' are not valid, got: "
-                + str(bounds)
+                f"Given bounds for 'len_scale' are not valid, got: {bounds}"
             )
         self._len_scale_bounds = bounds
 
@@ -812,7 +807,7 @@ class CovModel:
     def nugget_bounds(self, bounds):
         if not check_bounds(bounds):
             raise ValueError(
-                "Given bounds for 'nugget' are not valid, got: " + str(bounds)
+                f"Given bounds for 'nugget' are not valid, got: {bounds}"
             )
         self._nugget_bounds = bounds
 
@@ -832,7 +827,7 @@ class CovModel:
     def anis_bounds(self, bounds):
         if not check_bounds(bounds):
             raise ValueError(
-                "Given bounds for 'anis' are not valid, got: " + str(bounds)
+                f"Given bounds for 'anis' are not valid, got: {bounds}"
             )
         self._anis_bounds = bounds
 
@@ -1001,9 +996,8 @@ class CovModel:
             self.len_scale = integral_scale / int_tmp
             if not np.isclose(self.integral_scale, integral_scale, rtol=1e-3):
                 raise ValueError(
-                    self.name
-                    + ": Integral scale could not be set correctly!"
-                    + " Please just give a len_scale!"
+                    f"{self.name}: Integral scale could not be set correctly! "
+                    "Please just provide a 'len_scale'!"
                 )
 
     @property

--- a/gstools/covmodel/fit.py
+++ b/gstools/covmodel/fit.py
@@ -36,7 +36,7 @@ def fit_variogram(
     max_eval=None,
     return_r2=False,
     curve_fit_kwargs=None,
-    **para_select
+    **para_select,
 ):
     """
     Fitting a variogram-model to an empirical variogram.
@@ -217,9 +217,7 @@ def _pre_para(model, para_select, sill, anis):
     var_last = False
     for par in para_select:
         if par not in model.arg_bounds:
-            raise ValueError(
-                "fit: unknow parameter in selection: {}".format(par)
-            )
+            raise ValueError(f"fit: unknown parameter in selection: {par}")
         if not isinstance(para_select[par], bool):
             if par == "var":
                 var_last = True
@@ -288,16 +286,12 @@ def _pre_init_guess(model, init_guess, mean_x=1.0, mean_y=1.0):
     # "default" init guess is the respective default value
     default_guess = init_guess.pop("default", "default")
     if default_guess not in ["default", "current"]:
-        raise ValueError(
-            "fit_variogram: unknown def. guess: {}".format(default_guess)
-        )
+        raise ValueError(f"fit_variogram: unknown def. guess: {default_guess}")
     default = default_guess == "default"
     # check invalid names for given init guesses
     invalid_para = set(init_guess) - set(model.iso_arg + ["anis"])
     if invalid_para:
-        raise ValueError(
-            "fit_variogram: unknown init guess: {}".format(invalid_para)
-        )
+        raise ValueError(f"fit_variogram: unknown init guess: {invalid_para}")
     bnd = model.arg_bounds
     # default length scale is mean of given bin centers (respecting "rescale")
     init_guess.setdefault(

--- a/gstools/covmodel/plot.py
+++ b/gstools/covmodel/plot.py
@@ -117,7 +117,7 @@ def plot_variogram(
     if x_max is None:
         x_max = 3 * model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault("label", model.name + " variogram")
+    kwargs.setdefault("label", f"{model.name} variogram")
     ax.plot(x_s, model.variogram(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -132,7 +132,7 @@ def plot_covariance(
     if x_max is None:
         x_max = 3 * model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault("label", model.name + " covariance")
+    kwargs.setdefault("label", f"{model.name} covariance")
     ax.plot(x_s, model.covariance(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -147,7 +147,7 @@ def plot_correlation(
     if x_max is None:
         x_max = 3 * model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault("label", model.name + " correlation")
+    kwargs.setdefault("label", f"{model.name} correlation")
     ax.plot(x_s, model.correlation(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -162,7 +162,7 @@ def plot_vario_yadrenko(
     if x_max is None:
         x_max = min(3 * model.len_rescaled, np.pi)
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault("label", model.name + " Yadrenko variogram")
+    kwargs.setdefault("label", f"{model.name} Yadrenko variogram")
     ax.plot(x_s, model.vario_yadrenko(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -177,7 +177,7 @@ def plot_cov_yadrenko(
     if x_max is None:
         x_max = min(3 * model.len_rescaled, np.pi)
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault("label", model.name + " Yadrenko covariance")
+    kwargs.setdefault("label", f"{model.name} Yadrenko covariance")
     ax.plot(x_s, model.cov_yadrenko(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -192,7 +192,7 @@ def plot_cor_yadrenko(
     if x_max is None:
         x_max = min(3 * model.len_rescaled, np.pi)
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault("label", model.name + " Yadrenko correlation")
+    kwargs.setdefault("label", f"{model.name} Yadrenko correlation")
     ax.plot(x_s, model.cor_yadrenko(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -207,9 +207,7 @@ def plot_vario_axis(
     if x_max is None:
         x_max = 3 * model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault(
-        "label", model.name + " variogram on axis {}".format(axis)
-    )
+    kwargs.setdefault("label", f"{model.name} variogram on axis {axis}")
     ax.plot(x_s, model.vario_axis(x_s, axis), **kwargs)
     ax.legend()
     fig.show()
@@ -224,9 +222,7 @@ def plot_cov_axis(
     if x_max is None:
         x_max = 3 * model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault(
-        "label", model.name + " covariance on axis {}".format(axis)
-    )
+    kwargs.setdefault("label", f"{model.name} covariance on axis {axis}")
     ax.plot(x_s, model.cov_axis(x_s, axis), **kwargs)
     ax.legend()
     fig.show()
@@ -241,9 +237,7 @@ def plot_cor_axis(
     if x_max is None:
         x_max = 3 * model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault(
-        "label", model.name + " correlation on axis {}".format(axis)
-    )
+    kwargs.setdefault("label", f"{model.name} correlation on axis {axis}")
     ax.plot(x_s, model.cor_axis(x_s, axis), **kwargs)
     ax.legend()
     fig.show()
@@ -258,9 +252,7 @@ def plot_spectrum(
     if x_max is None:
         x_max = 3 / model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault(
-        "label", model.name + " " + str(model.dim) + "D spectrum"
-    )
+    kwargs.setdefault("label", f"{model.name} {model.dim}D spectrum")
     ax.plot(x_s, model.spectrum(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -275,9 +267,7 @@ def plot_spectral_density(
     if x_max is None:
         x_max = 3 / model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault(
-        "label", model.name + " " + str(model.dim) + "D spectral-density"
-    )
+    kwargs.setdefault("label", f"{model.name} {model.dim}D spectral-density")
     ax.plot(x_s, model.spectral_density(x_s), **kwargs)
     ax.legend()
     fig.show()
@@ -292,9 +282,7 @@ def plot_spectral_rad_pdf(
     if x_max is None:
         x_max = 3 / model.len_scale
     x_s = np.linspace(x_min, x_max)
-    kwargs.setdefault(
-        "label", model.name + " " + str(model.dim) + "D spectral-rad-pdf"
-    )
+    kwargs.setdefault("label", f"{model.name} {model.dim}D spectral-rad-pdf")
     ax.plot(x_s, model.spectral_rad_pdf(x_s), **kwargs)
     ax.legend()
     fig.show()

--- a/gstools/covmodel/tools.py
+++ b/gstools/covmodel/tools.py
@@ -100,11 +100,9 @@ def _init_subclass(cls):
         abstract = False
     if abstract:
         raise TypeError(
-            "Can't instantiate class '"
-            + cls.__name__
-            + "', "
-            + "without providing at least one of the methods "
-            + "'cor', 'variogram', 'covariance' or 'correlation'."
+            f"Can't instantiate class '{cls.__name__}', "
+            "without providing at least one of the methods "
+            "'cor', 'variogram', 'covariance' or 'correlation'."
         )
 
 
@@ -134,7 +132,7 @@ def rad_fac(dim, r):
             dim
             * r ** (dim - 1)
             * np.sqrt(np.pi) ** dim
-            / sps.gamma(dim / 2.0 + 1.0)
+            / sps.gamma(dim / 2 + 1)
         )
     return fac
 
@@ -161,9 +159,9 @@ def set_opt_args(model, opt_arg):
     for opt_name in opt_arg:
         if opt_name not in default:
             warnings.warn(
-                "The given optional argument '{}' ".format(opt_name)
-                + "is unknown or has at least no defined standard value. "
-                + "Or you made a Typo... hehe.",
+                f"The given optional argument '{opt_name}' "
+                "is unknown or has at least no defined standard value. "
+                "Or you made a Typo... hehe.",
                 AttributeWarning,
             )
     # add the default vaules if not specified
@@ -176,10 +174,9 @@ def set_opt_args(model, opt_arg):
     for opt_name in opt_arg:
         if opt_name in dir(model):  # "dir" also respects properties
             raise ValueError(
-                "parameter '"
-                + opt_name
-                + "' has a 'bad' name, since it is already present in "
-                + "the class. It could not be added to the model"
+                f"parameter '{opt_name}' has a 'bad' name, "
+                "since it is already present in "
+                "the class. It could not be added to the model."
             )
         # Magic happens here
         setattr(model, opt_name, float(opt_arg[opt_name]))
@@ -514,10 +511,8 @@ def set_dim(model, dim):
         dim = model.fix_dim()
         if model.latlon and dim != 3:
             raise ValueError(
-                model.name
-                + ": using fixed dimension "
-                + str(model.fix_dim())
-                + ", which is not compatible with a latlon model."
+                f"{model.name}: using fixed dimension {model.fix_dim()}, "
+                "which is not compatible with a latlon model."
             )
     # force dim=3 for latlon models
     dim = 3 if model.latlon else dim
@@ -526,7 +521,7 @@ def set_dim(model, dim):
         raise ValueError("Only dimensions of d >= 1 are supported.")
     if not model.check_dim(dim):
         warnings.warn(
-            "Dimension {} is not appropriate for this model.".format(dim),
+            f"Dimension {dim} is not appropriate for this model.",
             AttributeWarning,
         )
     model._dim = int(dim)
@@ -589,21 +584,20 @@ def model_repr(model):  # pragma: no cover
     if model.latlon:
         std_str = (
             "{0}(latlon={1}, var={2:.{p}}, len_scale={3:.{p}}, "
-            "nugget={4:.{p}}".format(
+            "nugget={4:.{p}}{5})".format(
                 model.name,
                 model.latlon,
                 model.var,
                 model.len_scale,
                 model.nugget,
+                opt_str,
                 p=model._prec,
             )
-            + opt_str
-            + ")"
         )
     else:
         std_str = (
             "{0}(dim={1}, var={2:.{p}}, len_scale={3:.{p}}, "
-            "nugget={4:.{p}}, anis={5}, angles={6}".format(
+            "nugget={4:.{p}}, anis={5}, angles={6}{7})".format(
                 model.name,
                 model.dim,
                 model.var,
@@ -611,9 +605,8 @@ def model_repr(model):  # pragma: no cover
                 model.nugget,
                 list_format(model.anis, 3),
                 list_format(model.angles, 3),
+                opt_str,
                 p=model._prec,
             )
-            + opt_str
-            + ")"
         )
     return std_str

--- a/gstools/covmodel/tools.py
+++ b/gstools/covmodel/tools.py
@@ -56,41 +56,6 @@ class AttributeWarning(UserWarning):
     """Attribute warning for CovModel class."""
 
 
-# __init_subclass__ hack for Python 3.5
-
-if hasattr(object, "__init_subclass__"):
-    InitSubclassMeta = type
-else:
-
-    class InitSubclassMeta(type):  # pragma: no cover
-        """Metaclass that implements PEP 487 protocol.
-
-        Notes
-        -----
-        See :
-            https://www.python.org/dev/peps/pep-0487
-
-        taken from :
-            https://github.com/graphql-python/graphene/blob/master/graphene/pyutils/init_subclass.py
-        """
-
-        def __new__(cls, name, bases, ns, **kwargs):
-            """Create a new subclass."""
-            __init_subclass__ = ns.pop("__init_subclass__", None)
-            if __init_subclass__:
-                __init_subclass__ = classmethod(__init_subclass__)
-                ns["__init_subclass__"] = __init_subclass__
-            return super(InitSubclassMeta, cls).__new__(
-                cls, name, bases, ns, **kwargs
-            )
-
-        def __init__(cls, name, bases, ns, **kwargs):
-            super(InitSubclassMeta, cls).__init__(name, bases, ns)
-            super_class = super(cls, cls)
-            if hasattr(super_class, "__init_subclass__"):
-                super_class.__init_subclass__.__func__(cls, **kwargs)
-
-
 def _init_subclass(cls):
     """Initialize gstools covariance model."""
 

--- a/gstools/covmodel/tools.py
+++ b/gstools/covmodel/tools.py
@@ -7,7 +7,6 @@ GStools subpackage providing tools for the covariance-model.
 The following classes and functions are provided
 
 .. autosummary::
-   InitSubclassMeta
    AttributeWarning
    rad_fac
    set_opt_args
@@ -34,7 +33,6 @@ from gstools.tools.misc import list_format
 from gstools.tools.geometric import set_anis, set_angles
 
 __all__ = [
-    "InitSubclassMeta",
     "AttributeWarning",
     "rad_fac",
     "set_opt_args",

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -32,7 +32,7 @@ def _set_mean_trend(value, dim):
         return value
     value = np.array(value, dtype=np.double).ravel()
     if value.size > 1 and value.size != dim:  # vector mean
-        raise ValueError("Mean/Trend: Wrong size ({})".format(value))
+        raise ValueError(f"Mean/Trend: Wrong size ({value})")
     return value if value.size > 1 else value.item()
 
 
@@ -308,9 +308,7 @@ class Field:
                     "Streamflow plotting only supported for 2d case."
                 )
         else:
-            raise ValueError(
-                "Unknown field value type: {}".format(self.value_type)
-            )
+            raise ValueError(f"Unknown field value type: {self.value_type}")
 
         return r
 
@@ -363,7 +361,7 @@ class Field:
     @value_type.setter
     def value_type(self, value_type):
         if value_type not in VALUE_TYPES:
-            raise ValueError("Field: value type not in {}".format(VALUE_TYPES))
+            raise ValueError(f"Field: value type not in {VALUE_TYPES}")
         self._value_type = value_type
 
     @property

--- a/gstools/field/cond_srf.py
+++ b/gstools/field/cond_srf.py
@@ -142,7 +142,7 @@ class CondSRF(Field):
             self._generator = gen(self.model, **generator_kwargs)
             self.value_type = self.generator.value_type
         else:
-            raise ValueError("gstools.CondSRF: Unknown generator " + generator)
+            raise ValueError(f"gstools.CondSRF: Unknown generator {generator}")
 
     @property
     def krige(self):

--- a/gstools/field/generator.py
+++ b/gstools/field/generator.py
@@ -80,7 +80,7 @@ class RandMeth:
         seed=None,
         verbose=False,
         sampling="auto",
-        **kwargs
+        **kwargs,
     ):
         if kwargs:
             warnings.warn("gstools.RandMeth: **kwargs are ignored")
@@ -192,13 +192,13 @@ class RandMeth:
             else:
                 raise ValueError(
                     "gstools.field.generator.RandMeth: "
-                    + "neither 'model' nor 'seed' given!"
+                    "neither 'model' nor 'seed' given!"
                 )
         # wrong model type
         else:
             raise ValueError(
                 "gstools.field.generator.RandMeth: 'model' is not an "
-                + "instance of 'gstools.CovModel'"
+                "instance of 'gstools.CovModel'"
             )
 
     def reset_seed(self, seed=np.nan):
@@ -249,7 +249,7 @@ class RandMeth:
     @sampling.setter
     def sampling(self, sampling):
         if sampling not in ["auto", "inversion", "mcmc"]:
-            raise ValueError("RandMeth: sampling not in {}.".format(SAMPLING))
+            raise ValueError(f"RandMeth: sampling not in {SAMPLING}.")
         self._sampling = sampling
 
     @property
@@ -310,7 +310,7 @@ class RandMeth:
     def __repr__(self):
         """Return String representation."""
         return "RandMeth(model={0}, mode_no={1}, seed={2})".format(
-            repr(self.model), self._mode_no, self.seed
+            self.model, self._mode_no, self.seed
         )
 
 
@@ -374,7 +374,7 @@ class IncomprRandMeth(RandMeth):
         seed=None,
         verbose=False,
         sampling="auto",
-        **kwargs
+        **kwargs,
     ):
         if model.dim < 2 or model.dim > 3:
             raise ValueError(

--- a/gstools/field/plot.py
+++ b/gstools/field/plot.py
@@ -82,7 +82,7 @@ def plot_1d(pos, field, fig=None, ax=None, ax_names=None):  # pragma: no cover
         Axis containing the plot.
     """
     fig, ax = _get_fig_ax(fig, ax)
-    title = "Field 1D: " + str(field.shape)
+    title = f"Field 1D: {field.shape}"
     x = pos[0]
     x = x.flatten()
     arg = np.argsort(x)
@@ -108,7 +108,7 @@ def plot_nd(
     show_colorbar=True,
     convex_hull=False,
     contour_plot=True,
-    **kwargs
+    **kwargs,
 ):  # pragma: no cover
     """
     Plot field in arbitrary dimensions.
@@ -167,9 +167,7 @@ def plot_nd(
     ax_names = _ax_names(dim, latlon, ax_names)
     # init planes
     planes = rotation_planes(dim)
-    plane_names = [
-        " {} - {}".format(ax_names[p[0]], ax_names[p[1]]) for p in planes
-    ]
+    plane_names = [f" {ax_names[p[0]]} - {ax_names[p[1]]}" for p in planes]
     ax_ends = [[p.min(), p.max()] for p in pos]
     ax_rngs = [end[1] - end[0] for end in ax_ends]
     ax_steps = [rng / resolution for rng in ax_rngs]
@@ -177,7 +175,7 @@ def plot_nd(
     # create figure
     reformat = fig is None and ax is None
     fig, ax = _get_fig_ax(fig, ax)
-    ax.set_title("Field {}D {} {}".format(dim, mesh_type, field.shape))
+    ax.set_title(f"Field {dim}D {mesh_type} {field.shape}")
     if reformat:  # only format fig if it was created here
         fig.set_size_inches(8, 5.5 + 0.5 * (dim - 2))
     # init additional axis, radio-buttons and sliders
@@ -306,7 +304,7 @@ def plot_vec_field(fld, field="field", fig=None, ax=None):  # pragma: no cover
     norm = np.sqrt(plot_field[0, :].T ** 2 + plot_field[1, :].T ** 2)
 
     fig, ax = _get_fig_ax(fig, ax)
-    title = "Field 2D " + fld.mesh_type + ": " + str(plot_field.shape)
+    title = f"Field 2D {fld.mesh_type}: {plot_field.shape}"
     x = fld.pos[0]
     y = fld.pos[1]
 
@@ -334,7 +332,7 @@ def _ax_names(dim, latlon=False, ax_names=None):
         return ["lon", "lat"]
     if dim <= 3:
         return ["$x$", "$y$", "$z$"][:dim] + (dim == 1) * ["field"]
-    return ["$x_{" + str(i) + "}$" for i in range(dim)]
+    return [f"$x_{{{i}}}$" for i in range(dim)]
 
 
 def _plot_2d(
@@ -350,7 +348,7 @@ def _plot_2d(
 ):  # pragma: no cover
     """Plot a 2d field with a contour plot."""
     fig, ax = _get_fig_ax(fig, ax)
-    title = "Field 2D " + mesh_type + ": " + str(field.shape)
+    title = f"Field 2D {mesh_type}: {field.shape}"
     ax_names = _ax_names(2, latlon, ax_names=ax_names)
     x, y = pos[::-1] if latlon else pos
     if mesh_type == "unstructured":

--- a/gstools/field/srf.py
+++ b/gstools/field/srf.py
@@ -89,7 +89,7 @@ class SRF(Field):
         trend=None,
         upscaling="no_scaling",
         generator="RandMeth",
-        **generator_kwargs
+        **generator_kwargs,
     ):
         super().__init__(model, mean=mean, normalizer=normalizer, trend=trend)
         # initialize private attributes
@@ -162,11 +162,11 @@ class SRF(Field):
             self._generator = gen(self.model, **generator_kwargs)
             self.value_type = self._generator.value_type
         else:
-            raise ValueError("gstools.SRF: Unknown generator: " + generator)
+            raise ValueError(f"gstools.SRF: Unknown generator: {generator}")
         for val in [self.mean, self.trend]:
             if not callable(val) and val is not None:
                 if np.size(val) > 1 and self.value_type == "scalar":
-                    raise ValueError("Mean/Trend: Wrong size ({})".format(val))
+                    raise ValueError(f"Mean/Trend: Wrong size ({val})")
 
     @property
     def generator(self):
@@ -191,9 +191,7 @@ class SRF(Field):
             self._upscaling = upscaling
             self._upscaling_func = UPSCALING[upscaling]
         else:
-            raise ValueError(
-                "gstools.SRF: Unknown upscaling method: " + upscaling
-            )
+            raise ValueError(f"SRF: Unknown upscaling method: {upscaling}")
 
     def __repr__(self):
         """Return String representation."""

--- a/gstools/field/tools.py
+++ b/gstools/field/tools.py
@@ -7,8 +7,9 @@ GStools subpackage providing tools for Fields.
 The following classes and functions are provided
 
 .. autosummary::
+   fmt_mean_norm_trend
    to_vtk_helper
-   mesh_call
+   generate_on_mesh
 """
 import numpy as np
 import meshio
@@ -18,7 +19,7 @@ from gstools.tools.export import to_vtk, vtk_export
 from gstools.tools.misc import list_format
 
 
-__all__ = ["fmt_mean_norm_trend", "to_vtk_helper", "mesh_call"]
+__all__ = ["fmt_mean_norm_trend", "to_vtk_helper", "generate_on_mesh"]
 
 
 def _fmt_func_val(f_cls, func_val):  # pragma: no cover
@@ -95,11 +96,9 @@ def to_vtk_helper(
                     filename, f_cls.pos, {fieldname: field}, f_cls.mesh_type
                 )
         else:
-            print("Field.to_vtk: '{}' not available.".format(field_select))
+            raise ValueError(f"Field.to_vtk: '{field_select}' not available.")
     else:
-        raise ValueError(
-            "Unknown field value type: {}".format(f_cls.value_type)
-        )
+        raise ValueError(f"Unknown field value type: {f_cls.value_type}")
 
 
 def generate_on_mesh(
@@ -167,9 +166,8 @@ def generate_on_mesh(
         select = direction[: f_cls.dim]
     if len(select) < f_cls.dim:
         raise ValueError(
-            "Field.mesh: need at least {} direction(s), got '{}'".format(
-                f_cls.dim, direction
-            )
+            f"Field.mesh: need at least {f_cls.dim} direction(s), "
+            f"got '{direction}'"
         )
     # convert pyvista mesh
     if has_pyvista and pv.is_pyvista_dataset(mesh):
@@ -235,7 +233,7 @@ def generate_on_mesh(
 def _names(name, cnt):
     name = [name] if isinstance(name, str) else list(name)[:cnt]
     if len(name) < cnt:
-        name += [name[-1] + str(i + 1) for i in range(cnt - len(name))]
+        name += [f"{name[-1]}{i + 1}" for i in range(cnt - len(name))]
     return name
 
 
@@ -243,29 +241,27 @@ def _get_select(direction):
     select = []
     if not (0 < len(direction) < 4):
         raise ValueError(
-            "Field.mesh: need 1 to 3 direction(s), got '{}'".format(direction)
+            f"Field.mesh: need 1 to 3 direction(s), got '{direction}'"
         )
     for axis in direction:
         if axis == "x":
             if 0 in select:
                 raise ValueError(
-                    "Field.mesh: got duplicate directions {}".format(direction)
+                    f"Field.mesh: got duplicate directions {direction}"
                 )
             select.append(0)
         elif axis == "y":
             if 1 in select:
                 raise ValueError(
-                    "Field.mesh: got duplicate directions {}".format(direction)
+                    f"Field.mesh: got duplicate directions {direction}"
                 )
             select.append(1)
         elif axis == "z":
             if 2 in select:
                 raise ValueError(
-                    "Field.mesh: got duplicate directions {}".format(direction)
+                    f"Field.mesh: got duplicate directions {direction}"
                 )
             select.append(2)
         else:
-            raise ValueError(
-                "Field.mesh: got unknown direction {}".format(axis)
-            )
+            raise ValueError(f"Field.mesh: got unknown direction {axis}")
     return select

--- a/gstools/normalizer/base.py
+++ b/gstools/normalizer/base.py
@@ -217,7 +217,7 @@ class Normalizer:
             return -self.kernel_loglikelihood(dat)
 
         if len(para_names) == 0:  # transformations without para. (no opti.)
-            warnings.warn(self.name + ".fit: no parameters!")
+            warnings.warn(f"{self.name}.fit: no parameters!")
             return {}
         if len(para_names) == 1:  # one-para. transformations (simple opti.)
             # default bracket like in scipy's boxcox (if not given)
@@ -255,4 +255,4 @@ class Normalizer:
             "{0}={1:.{2}}".format(p, float(getattr(self, p)), self._prec)
             for p in sorted(self.default_parameter)
         ]
-        return self.name + "(" + ", ".join(para_strs) + ")"
+        return f"{self.name}({', '.join(para_strs)})"

--- a/gstools/random/rng.py
+++ b/gstools/random/rng.py
@@ -216,4 +216,4 @@ class RNG:
 
     def __repr__(self):
         """Return String representation."""
-        return "RNG(seed={})".format(self.seed)
+        return f"RNG(seed={self.seed})"

--- a/gstools/random/tools.py
+++ b/gstools/random/tools.py
@@ -48,7 +48,7 @@ class MasterRNG:
 
     def __repr__(self):
         """Return String representation."""
-        return "MasterRNG(seed={})".format(self.seed)
+        return f"MasterRNG(seed={self.seed})"
 
 
 def dist_gen(pdf_in=None, cdf_in=None, ppf_in=None, **kwargs):

--- a/gstools/tools/geometric.py
+++ b/gstools/tools/geometric.py
@@ -571,13 +571,13 @@ def ang2dir(angles, dtype=np.double, dim=None):
     pre_dim = np.asanyarray(angles).ndim
     angles = np.array(angles, ndmin=2, dtype=dtype)
     if len(angles.shape) > 2:
-        raise ValueError("Can't interpret angles array {}".format(angles))
+        raise ValueError(f"Can't interpret angles array {angles}")
     dim = angles.shape[1] + 1 if dim is None else dim
     if dim == 2 and angles.shape[0] == 1 and pre_dim < 2:
         # fix for 2D where only one angle per direction is given
         angles = angles.T  # can't be interpreted if dim=None is given
     if dim != angles.shape[1] + 1 or dim == 1:
-        raise ValueError("Wrong dim. ({}) for angles {}".format(dim, angles))
+        raise ValueError(f"Wrong dim. ({dim}) for angles {angles}")
     vec = np.empty((angles.shape[0], dim), dtype=dtype)
     vec[:, 0] = np.prod(np.sin(angles), axis=1)
     for i in range(1, dim):

--- a/gstools/tools/misc.py
+++ b/gstools/tools/misc.py
@@ -19,9 +19,7 @@ __all__ = ["list_format", "eval_func"]
 
 def list_format(lst, prec):  # pragma: no cover
     """Format a list of floats."""
-    return "[{}]".format(
-        ", ".join("{x:.{p}}".format(x=float(x), p=prec) for x in lst)
-    )
+    return f"[{', '.join(f'{float(x):.{prec}}' for x in lst)}]"
 
 
 def eval_func(

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -48,9 +48,7 @@ def _set_estimator(estimator):
     elif estimator.lower() == "cressie":
         cython_estimator = "c"
     else:
-        raise ValueError(
-            "Unknown variogram estimator function " + str(estimator)
-        )
+        raise ValueError(f"Unknown variogram estimator function: {estimator}")
     return cython_estimator
 
 
@@ -285,9 +283,9 @@ def vario_estimate(
     if direction is not None and dim > 1:
         direction = np.array(direction, ndmin=2, dtype=np.double)
         if len(direction.shape) > 2:
-            raise ValueError("Can't interpret directions {}".format(direction))
+            raise ValueError(f"Can't interpret directions: {direction}")
         if direction.shape[1] != dim:
-            raise ValueError("Can't interpret directions {}".format(direction))
+            raise ValueError(f"Can't interpret directions: {direction}")
         dir_no = direction.shape[0]
     # convert given angles to direction vector
     if angles is not None and direction is None and dim > 1:
@@ -299,7 +297,7 @@ def vario_estimate(
             raise ValueError("Directional variogram not allowed for lat-lon.")
         norms = np.linalg.norm(direction, axis=1)
         if np.any(np.isclose(norms, 0)):
-            raise ValueError("Zero length direction {}".format(direction))
+            raise ValueError(f"Zero length directions: {direction}")
         # only unit-vectors for directions
         direction = np.divide(direction, norms[:, np.newaxis])
         # negative bandwidth to turn it off

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,6 @@ CLASSIFIERS = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Python 3.5 had its EOL in September 2020 and Ubuntu 16.04 LTS (where Python 3.5 was installed by default) has its End of Standard Support in April 2021. Let's drop support now.

Changes:
- Use `ModuleNotFoundError` when version file could not be found (was not present in py35)
- remove metaclass hack for py35 in `CovModel`
- Use new Github action for `cibuildwheel`
- update setup requirement versions for wheels built: `numpy==1.19.* cython==0.29.*`
- pin version for pypi gh-action