### PR TITLE
Tests: remove tests with np.int which is a deprecated alias for buitin int

### DIFF
--- a/tests/test_variogram_structured.py
+++ b/tests/test_variogram_structured.py
@@ -25,11 +25,6 @@ class TestVariogramstructured(unittest.TestCase):
         gamma = gs.vario_estimate_axis(z)
         self.assertAlmostEqual(gamma[1], 50.0, places=4)
 
-    def test_np_int(self):
-        z = np.array((10, 20, 30, 40), dtype=np.int)
-        gamma = gs.vario_estimate_axis(z)
-        self.assertAlmostEqual(gamma[1], 50.0, places=4)
-
     def test_mixed(self):
         z = np.array(
             (41.2, 40.2, 39.7, 39.2, 40.1, 38.3, 39.1, 40.0, 41.1, 40.3),

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -33,13 +33,6 @@ class TestVariogramUnstructured(unittest.TestCase):
         bin_centres, gamma = gs.vario_estimate([x], z, bins)
         self.assertAlmostEqual(gamma[0], 50.0, places=4)
 
-    def test_np_int(self):
-        x = np.arange(1, 5, 1, dtype=np.int)
-        z = np.array((10, 20, 30, 40), dtype=np.int)
-        bins = np.arange(1, 11, 1, dtype=np.int)
-        bin_centres, gamma = gs.vario_estimate([x], z, bins)
-        self.assertAlmostEqual(gamma[0], 50.0, places=4)
-
     def test_mixed(self):
         x = np.arange(1, 11, 1, dtype=np.double)
         z = np.array(


### PR DESCRIPTION
`np.int` will disappear in the future: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations