### PR TITLE
sdist: only include necessary files and tests (no doc)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,7 @@
 prune *
 graft tests
-graft docs
 recursive-include gstools *.py *.pyx
 recursive-exclude gstools *.c *.cpp
-include LICENSE pyproject.toml setup.py setup.cfg
-include *.md
+include LICENSE README.md pyproject.toml setup.py setup.cfg
+exclude CHANGELOG.md CONTRIBUTING.md AUTHORS.md
 global-exclude __pycache__ *.py[cod] .*


### PR DESCRIPTION
update `MANIFEST.in` to only include necessary files (gstools, tests, LICENSE, README.md, pyproject.toml, setup.py, setup.cfg) and to exclude docs.