### PR TITLE
Covmodel arg bugfix: Always convert nugget to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ All notable changes to **GSTools** will be documented in this file.
 - default init guess for `len_scale` is now mean of given bin-centers
 - default init guess for `var` and `nugget` is now mean of given variogram values
 
-#### CovModel update ([#109](https://github.com/GeoStat-Framework/GSTools/issues/109), [#122](https://github.com/GeoStat-Framework/GSTools/issues/122))
+#### CovModel update ([#109](https://github.com/GeoStat-Framework/GSTools/issues/109), [#122](https://github.com/GeoStat-Framework/GSTools/issues/122), [#157](https://github.com/GeoStat-Framework/GSTools/pull/157))
 - add new `rescale` argument and attribute to the `CovModel` class to be able to rescale the `len_scale` (usefull for unit conversion or rescaling `len_scale` to coincide with the `integral_scale` like it's the case with the Gaussian model)
   See: [#90](https://github.com/GeoStat-Framework/GSTools/issues/90), [GeoStat-Framework/PyKrige#119](https://github.com/GeoStat-Framework/PyKrige/issues/119)
 - added new `len_rescaled` attribute to the `CovModel` class, which is the rescaled `len_scale`: `len_rescaled = len_scale / rescale`
@@ -82,7 +82,9 @@ All notable changes to **GSTools** will be documented in this file.
   - `JBessel`: a hole model valid in all dimensions. The shape parameter controls the dimension it was derived from. For `nu=0.5` this model coincides with the well known `wave` hole model.
   - `TPLSimple`: a simple truncated power law controlled by a shape parameter `nu`. Coincides with the truncated linear model for `nu=1`
   - `Cubic`: to be compatible with scikit-gstat in the future
+- all arguments are now stored as float internally ([#157](https://github.com/GeoStat-Framework/GSTools/pull/157))
 - string representation of the `CovModel` class is now using a float precision (`CovModel._prec=3`) to truncate longish output
+- string representation of the `CovModel` class now only shows `anis` and `angles` if model is anisotropic resp. rotated
 - dimension validity check: raise a warning, if given model is not valid in the desired dimension (See: [#86](https://github.com/GeoStat-Framework/GSTools/issues/86))
 
 #### Normalizer, Trend and Mean ([#124](https://github.com/GeoStat-Framework/GSTools/issues/124))

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -172,7 +172,7 @@ class CovModel:
 
         # set parameters
         self.rescale = rescale
-        self._nugget = nugget
+        self._nugget = float(nugget)
         # set anisotropy and len_scale, disable anisotropy for latlon models
         self._len_scale, anis = set_len_anis(self.dim, len_scale, anis)
         if self.latlon:
@@ -186,7 +186,7 @@ class CovModel:
             self._var = None
             self.var = var
         else:
-            self._var = var_raw
+            self._var = float(var_raw)
         self._integral_scale = None
         self.integral_scale = integral_scale
         # set var again, if int_scale affects var_factor
@@ -194,7 +194,7 @@ class CovModel:
             self._var = None
             self.var = var
         else:
-            self._var = var_raw
+            self._var = float(var_raw)
         # final check for parameter bounds
         self.check_arg_bounds()
         # additional checks for the optional arguments (provided by user)
@@ -893,7 +893,7 @@ class CovModel:
 
     @var.setter
     def var(self, var):
-        self._var = var / self.var_factor()
+        self._var = float(var) / self.var_factor()
         self.check_arg_bounds()
 
     @property
@@ -906,7 +906,7 @@ class CovModel:
 
     @var_raw.setter
     def var_raw(self, var_raw):
-        self._var = var_raw
+        self._var = float(var_raw)
         self.check_arg_bounds()
 
     @property
@@ -916,7 +916,7 @@ class CovModel:
 
     @nugget.setter
     def nugget(self, nugget):
-        self._nugget = nugget
+        self._nugget = float(nugget)
         self.check_arg_bounds()
 
     @property

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    CovModel
 """
-# pylint: disable=C0103, R0201
+# pylint: disable=C0103, R0201, E1101
 
 import copy
 import numpy as np

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -146,6 +146,7 @@ class CovModel:
         self._hankel_kw = None
         self._sft = None
         # prepare parameters (they are checked in dim setting)
+        self._rescale = None
         self._len_scale = None
         self._anis = None
         self._angles = None
@@ -170,9 +171,7 @@ class CovModel:
         self.set_arg_bounds(check_args=False, **bounds)
 
         # set parameters
-        self._rescale = (
-            self.default_rescale() if rescale is None else abs(float(rescale))
-        )
+        self.rescale = rescale
         self._nugget = nugget
         # set anisotropy and len_scale, disable anisotropy for latlon models
         self._len_scale, anis = set_len_anis(self.dim, len_scale, anis)
@@ -938,6 +937,11 @@ class CovModel:
     def rescale(self):
         """:class:`float`: Rescale factor for the length scale of the model."""
         return self._rescale
+
+    @rescale.setter
+    def rescale(self, rescale):
+        rescale = self.default_rescale() if rescale is None else rescale
+        self._rescale = abs(float(rescale))
 
     @property
     def len_rescaled(self):

--- a/gstools/covmodel/tools.py
+++ b/gstools/covmodel/tools.py
@@ -576,11 +576,19 @@ def model_repr(model):  # pragma: no cover
     model : :any:`CovModel`
         The covariance model in use.
     """
-    opt_str = ""
+    if not np.isclose(model.rescale, model.default_rescale()):
+        opt_str = ", rescale={0:.{p}}".format(model.rescale, p=model._prec)
+    else:
+        opt_str = ""
     for opt in model.opt_arg:
-        opt_str += (
-            ", " + opt + "={0:.{1}}".format(getattr(model, opt), model._prec)
+        opt_str += ", {0}={1:.{p}}".format(
+            opt, getattr(model, opt), p=model._prec
         )
+    # only print anis and angles if model is anisotropic or rotated
+    ani = "" if model.is_isotropic else f", anis={list_format(model.anis, 3)}"
+    ang = (
+        f", angles={list_format(model.angles, 3)}" if model.do_rotation else ""
+    )
     if model.latlon:
         std_str = (
             "{0}(latlon={1}, var={2:.{p}}, len_scale={3:.{p}}, "
@@ -597,14 +605,14 @@ def model_repr(model):  # pragma: no cover
     else:
         std_str = (
             "{0}(dim={1}, var={2:.{p}}, len_scale={3:.{p}}, "
-            "nugget={4:.{p}}, anis={5}, angles={6}{7})".format(
+            "nugget={4:.{p}}{5}{6}{7})".format(
                 model.name,
                 model.dim,
                 model.var,
                 model.len_scale,
                 model.nugget,
-                list_format(model.anis, 3),
-                list_format(model.angles, 3),
+                ani,
+                ang,
                 opt_str,
                 p=model._prec,
             )

--- a/gstools/covmodel/tools.py
+++ b/gstools/covmodel/tools.py
@@ -576,45 +576,25 @@ def model_repr(model):  # pragma: no cover
     model : :any:`CovModel`
         The covariance model in use.
     """
-    if not np.isclose(model.rescale, model.default_rescale()):
-        opt_str = ", rescale={0:.{p}}".format(model.rescale, p=model._prec)
-    else:
-        opt_str = ""
-    for opt in model.opt_arg:
-        opt_str += ", {0}={1:.{p}}".format(
-            opt, getattr(model, opt), p=model._prec
-        )
+    m = model
+    p = model._prec
+    opt_str = ""
+    if not np.isclose(m.rescale, m.default_rescale()):
+        opt_str += f", rescale={m.rescale:.{p}}"
+    for opt in m.opt_arg:
+        opt_str += f", {opt}={getattr(m, opt):.{p}}"
     # only print anis and angles if model is anisotropic or rotated
-    ani = "" if model.is_isotropic else f", anis={list_format(model.anis, 3)}"
-    ang = (
-        f", angles={list_format(model.angles, 3)}" if model.do_rotation else ""
-    )
-    if model.latlon:
-        std_str = (
-            "{0}(latlon={1}, var={2:.{p}}, len_scale={3:.{p}}, "
-            "nugget={4:.{p}}{5})".format(
-                model.name,
-                model.latlon,
-                model.var,
-                model.len_scale,
-                model.nugget,
-                opt_str,
-                p=model._prec,
-            )
+    ani_str = "" if m.is_isotropic else f", anis={list_format(m.anis, p)}"
+    ang_str = f", angles={list_format(m.angles, p)}" if m.do_rotation else ""
+    if m.latlon:
+        repr_str = (
+            f"{m.name}(latlon={m.latlon}, var={m.var:.{p}}, "
+            f"len_scale={m.len_scale:.{p}}, nugget={m.nugget:.{p}}{opt_str})"
         )
     else:
-        std_str = (
-            "{0}(dim={1}, var={2:.{p}}, len_scale={3:.{p}}, "
-            "nugget={4:.{p}}{5}{6}{7})".format(
-                model.name,
-                model.dim,
-                model.var,
-                model.len_scale,
-                model.nugget,
-                ani,
-                ang,
-                opt_str,
-                p=model._prec,
-            )
+        repr_str = (
+            f"{m.name}(dim={m.dim}, var={m.var:.{p}}, "
+            f"len_scale={m.len_scale:.{p}}, nugget={m.nugget:.{p}}"
+            f"{ani_str}{ang_str}{opt_str})"
         )
-    return std_str
+    return repr_str


### PR DESCRIPTION
This line of code generated an Error with `gstools==1.3.0rc2`:
```python
import gstools as gs
print(gs.Matern(nugget=0))
```
```bash
ValueError: Precision not allowed in integer format specifier
```

Reason: `nugget` was never converted to `float` internally and is stored as `int` (which is totally fine for all calculations), but the printing routine tries to format it as float.

This PR solves this problem and adds some minor additions:
- `rescale` was not setable after the model was instantiated: added `rescale.setter`
- `rescale` didn't show up in the `repr` string: fixed if rescale is not the default value
- `anis` and `angles` where always showing up also for isotropic and unrotated models: fixed

This means, the repr is the exact init sequence to create a model:
```python
from gstools import Matern
exec(f"m={Matern()}")
print(m)
```
```bash
Matern(dim=3, var=1.0, len_scale=1.0, nugget=0.0, nu=1.0)
```
The conditional repr looks like the following:
```python
from gstools import Matern
print(Matern(rescale=2))
print(Matern(anis=2))
print(Matern(angles=1))
print(Matern(rescale=2, anis=2, angles=1))
```
```bash
Matern(dim=3, var=1.0, len_scale=1.0, nugget=0.0, rescale=2.0, nu=1.0)
Matern(dim=3, var=1.0, len_scale=1.0, nugget=0.0, anis=[1.0, 2.0], nu=1.0)
Matern(dim=3, var=1.0, len_scale=1.0, nugget=0.0, angles=[1.0, 0.0, 0.0], nu=1.0)
Matern(dim=3, var=1.0, len_scale=1.0, nugget=0.0, anis=[1.0, 2.0], angles=[1.0, 0.0, 0.0], rescale=2.0, nu=1.0)
```