### PR TITLE
Pylint fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   source_check:
-    name: format check
+    name: source check
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,6 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install black pylint
+          pip install --editable .
 
       - name: black check
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  format_check:
+  source_check:
     name: format check
     runs-on: ubuntu-latest
     strategy:
@@ -31,11 +31,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          pip install black pylint
 
       - name: black check
         run: |
           python -m black --check .
+
+      - name: pylint check
+        run: |
+          python -m pylint gstools/
 
   build_wheels:
     name: wheels on ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ All notable changes to **GSTools** will be documented in this file.
 - renamed `estimate_unstructured` and `estimate_structured` to `vario_estimate_unstructured` and `vario_estimate_structured` for less ambiguity
 
 ### Bugfixes
+- several pylint fixes ([#159](https://github.com/GeoStat-Framework/GSTools/pull/159))
 - several minor bugfixes
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to **GSTools** will be documented in this file.
 #### Directional Variograms and Auto-binning ([#87](https://github.com/GeoStat-Framework/GSTools/issues/87), [#106](https://github.com/GeoStat-Framework/GSTools/issues/106), [#131](https://github.com/GeoStat-Framework/GSTools/issues/131))
 - new routine name `vario_estimate` instead of `vario_estimate_unstructured` (old kept for legacy code) for simplicity
 - new routine name `vario_estimate_axis` instead of `vario_estimate_structured` (old kept for legacy code) for simplicity
-- **`vario_estimate`**
+- **vario_estimate**
   - added simple automatic binning routine to determine bins from given data (one third of box diameter as max bin distance, sturges rule for number of bins)
   - allow to pass multiple fields for joint variogram estimation (e.g. for daily precipitation) on same mesh
   - `no_data` option added to allow missing values
@@ -53,7 +53,7 @@ All notable changes to **GSTools** will be documented in this file.
     - prepared for nD
   - structured fields (pos tuple describes axes) can now be passed to estimate an isotropic or directional variogram
   - distance calculation in cython routines in now independent of dimension
-- **`vario_estimate_axis`**
+- **vario_estimate_axis**
   - estimation along array axis now possible in arbitrary dimensions
   - `no_data` option added to allow missing values (sovles [#83](https://github.com/GeoStat-Framework/GSTools/issues/83))
   - axis can be given by name (`"x"`, `"y"`, `"z"`) or axis number (`0`, `1`, `2`, `3`, ...)
@@ -141,6 +141,7 @@ All notable changes to **GSTools** will be documented in this file.
 - isotropic rotation of SRF was not possible [#100](https://github.com/GeoStat-Framework/GSTools/issues/100)
 - `CovModel.opt_arg` now sorted [#103](https://github.com/GeoStat-Framework/GSTools/issues/103)
 - CovModel.fit: check if weights are given as a string (numpy comparison error) [#111](https://github.com/GeoStat-Framework/GSTools/issues/111)
+- several pylint fixes ([#159](https://github.com/GeoStat-Framework/GSTools/pull/159))
 
 ## [1.2.1] - Volatile Violet - 2020-04-14
 
@@ -180,13 +181,13 @@ All notable changes to **GSTools** will be documented in this file.
 ## [1.1.1] - Reverberating Red - 2019-11-08
 
 ### Enhancements
-- added a changelog. See: [commit](https://github.com/GeoStat-Framework/GSTools/commit/fbea88300d0862393e52f4b7c3d2b15c2039498b)
+- added a changelog. See: [commit fbea883](https://github.com/GeoStat-Framework/GSTools/commit/fbea88300d0862393e52f4b7c3d2b15c2039498b)
 
 ### Changes
 - deprecation warnings are now printed if Python versions 2.7 or 3.4 are used #40 #41
 
 ### Bugfixes
-- define spectral_density instead of spectrum in covariance models since Cov-base derives spectrum. See: [commit](https://github.com/GeoStat-Framework/GSTools/commit/00f2747fd0503ff8806f2eebfba36acff813416b)
+- define spectral_density instead of spectrum in covariance models since Cov-base derives spectrum. See: [commit 00f2747](https://github.com/GeoStat-Framework/GSTools/commit/00f2747fd0503ff8806f2eebfba36acff813416b)
 - better boundaries for CovModel parameters. See: https://github.com/GeoStat-Framework/GSTools/issues/37
 
 
@@ -201,8 +202,8 @@ All notable changes to **GSTools** will be documented in this file.
 - incompressible flow fields can now be generated #14
 - new submodule providing several field transformations like: Zinn&Harvey, log-normal, bimodal, ... #13
 - Python 3.4 and 3.7 wheel support #19
-- field can now be generated directly on meshes from [meshio](https://github.com/nschloe/meshio) and [ogs5py](https://github.com/GeoStat-Framework/ogs5py), see: [commit](https://github.com/GeoStat-Framework/GSTools/commit/f4a3439400b81d8d9db81a5f7fbf6435f603cf05)
-- the srf and kriging classes now store the last ``pos``, ``mesh_type`` and ``field`` values to keep them accessible, see: [commit](https://github.com/GeoStat-Framework/GSTools/commit/29f7f1b029866379ce881f44765f72534d757fae)
+- field can now be generated directly on meshes from [meshio](https://github.com/nschloe/meshio) and [ogs5py](https://github.com/GeoStat-Framework/ogs5py), see: [commit f4a3439](https://github.com/GeoStat-Framework/GSTools/commit/f4a3439400b81d8d9db81a5f7fbf6435f603cf05)
+- the srf and kriging classes now store the last ``pos``, ``mesh_type`` and ``field`` values to keep them accessible, see: [commit 29f7f1b](https://github.com/GeoStat-Framework/GSTools/commit/29f7f1b029866379ce881f44765f72534d757fae)
 - tutorials on all important features of GSTools have been written for you guys #20
 - a new interface to pyvista is provided to export fields to python vtk representation, which can be used for plotting, exploring and exporting fields #29
 
@@ -211,8 +212,8 @@ All notable changes to **GSTools** will be documented in this file.
 - the rotation angles are now interpreted in positive direction (counter clock wise)
 - the ``force_moments`` keyword was removed from the SRF call method, it is now in provided as a field transformation #13
 - drop support of python implementations of the variogram estimators #18
-- the ``variogram_normed`` method was removed from the ``CovModel`` class due to redundance [commit](https://github.com/GeoStat-Framework/GSTools/commit/25b164722ac6744ebc7e03f3c0bf1c30be1eba89)
-- the position vector of 1D fields does not have to be provided in a list-like object with length 1 [commit](https://github.com/GeoStat-Framework/GSTools/commit/a6f5be8bfd2db1f002e7889ecb8e9a037ea08886)
+- the ``variogram_normed`` method was removed from the ``CovModel`` class due to redundance [commit 25b1647](https://github.com/GeoStat-Framework/GSTools/commit/25b164722ac6744ebc7e03f3c0bf1c30be1eba89)
+- the position vector of 1D fields does not have to be provided in a list-like object with length 1 [commit a6f5be8](https://github.com/GeoStat-Framework/GSTools/commit/a6f5be8bfd2db1f002e7889ecb8e9a037ea08886)
 
 ### Bugfixes
 - several minor bugfixes
@@ -248,7 +249,6 @@ All notable changes to **GSTools** will be documented in this file.
 - renamed `estimate_unstructured` and `estimate_structured` to `vario_estimate_unstructured` and `vario_estimate_structured` for less ambiguity
 
 ### Bugfixes
-- several pylint fixes ([#159](https://github.com/GeoStat-Framework/GSTools/pull/159))
 - several minor bugfixes
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,66 @@ with your idea or suggestion and we'd love to discuss about it.
 
 - Fork the repo on [GitHub](https://github.com/GeoStat-Framework/GSTools) from the [develop branch](https://github.com/GeoStat-Framework/GSTools/tree/develop).
 - Add yourself to AUTHORS.md (if you want to).
-- We use the black code format, please use the script `black --line-length 79 gstools/` after you have written your code.
+- We use the black code format, please use the script `black .` after you have written your code.
 - Add some tests if possible.
 - Add an example showing your new feature in one of the examples sub-folders if possible.
   Follow this [Sphinx-Gallary guide](https://sphinx-gallery.github.io/stable/syntax.html#embed-rst-in-your-example-python-files)
 - Push to your fork and submit a pull request.
+
+### PyLint Settings
+
+Your code will be checked by [Pylint](https://github.com/PyCQA/pylint/)
+with `pylint gstools` in the CI.
+We made some generous default settings in `pyproject.toml` for the linter:
+
+- max-args = 20
+- max-locals = 50
+- max-branches = 30
+- max-statements = 80
+- max-attributes = 25
+- max-public-methods = 75
+
+Since some classes in GSTools are quite huge and some function signatures are
+somewhat longish.
+
+By default [R0801](https://vald-phoenix.github.io/pylint-errors/plerr/errors/similarities/R0801)
+(duplicate-code) is disabled, since it produces a lot of false positive errors
+for docstrings and `__init__.py` settings.
+
+We also disabled some pylint checks for some files by setting
+comments like these at the beginning:
+```python
+# pylint: disable=C0103
+```
+
+Here is a list of the occurring disabled errors:
+- [C0103](https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0103)
+  (invalid-name) - `ax`, `r` etc. are marked as no valid names
+- [C0302](https://vald-phoenix.github.io/pylint-errors/plerr/errors/format/C0302)
+  (too-many-lines) - namely the `CovModel` definition has more than 1000 lines
+- [C0415](https://vald-phoenix.github.io/pylint-errors/plerr/errors/imports/C0415)
+  (import-outside-toplevel) - needed sometimes for deferred imports of optional
+  dependencies like `matplotlib`
+- [R0201](https://vald-phoenix.github.io/pylint-errors/plerr/errors/classes/R0201)
+  (no-self-use) - methods with no `self` calls in some base-classes
+- [W0212](https://vald-phoenix.github.io/pylint-errors/plerr/errors/classes/W0212)
+  (protected-access) - we didn't want to draw attention to `CovModel._prec`
+- [W0221](https://vald-phoenix.github.io/pylint-errors/plerr/errors/classes/W0221)
+  (arguments-differ) - the `__call__` methods of `SRF` and `Krige` differ from `Field`
+- [W0222](https://vald-phoenix.github.io/pylint-errors/plerr/errors/classes/W0222)
+  (signature-differ) - the `__call__` methods of `SRF` and `Krige` differ from `Field`
+- [W0231](https://vald-phoenix.github.io/pylint-errors/plerr/errors/classes/W0231)
+  (super-init-not-called) - some child classes have their specialized `__init__`
+- [W0613](https://vald-phoenix.github.io/pylint-errors/plerr/errors/variables/W0613)
+  (unused-argument) - needed sometimes to match required call signatures
+- [W0632](https://vald-phoenix.github.io/pylint-errors/plerr/errors/variables/W0632)
+  (unbalanced-tuple-unpacking) - false positive for some call returns
+- [E1101](https://vald-phoenix.github.io/pylint-errors/plerr/errors/typecheck/E1101)
+  (no-member) - some times false positive
+- [E1102](https://vald-phoenix.github.io/pylint-errors/plerr/errors/typecheck/E1102)
+  (not-callable) - this is a false-positive result form some called properties
+- [E1130](https://vald-phoenix.github.io/pylint-errors/plerr/errors/typecheck/E1130)
+  (invalid-unary-operand-type) - false positive at some points
+
+Although we disabled these errors at some points, we encourage you to prevent
+disabling errors when it is possible.

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -10,7 +10,6 @@ The following classes are provided
    CovModel
 """
 # pylint: disable=C0103, R0201, E1101, C0302, W0613
-
 import copy
 import numpy as np
 from scipy.integrate import quad as integral

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    CovModel
 """
-# pylint: disable=C0103, R0201, E1101
+# pylint: disable=C0103, R0201, E1101, C0302, W0613
 
 import copy
 import numpy as np
@@ -212,14 +212,12 @@ class CovModel:
             cls.__doc__ = "User defined GSTools Covariance-Model."
         cls.__doc__ += CovModel.__doc__[45:]
         # overridden functions get standard doc if no new doc was created
-        ignore = ["__", "variogram", "covariance", "cor"]
-        for attr in cls.__dict__:
-            if any(
-                [attr.startswith(ign) for ign in ignore]
-            ) or attr not in dir(CovModel):
+        ign = ["__", "variogram", "covariance", "cor"]
+        for att in cls.__dict__:
+            if any(att.startswith(i) for i in ign) or att not in dir(CovModel):
                 continue
-            attr_doc = getattr(CovModel, attr).__doc__
-            attr_cls = cls.__dict__[attr]
+            attr_doc = getattr(CovModel, att).__doc__
+            attr_cls = cls.__dict__[att]
             if attr_cls.__doc__ is None:
                 attr_cls.__doc__ = attr_doc
 

--- a/gstools/covmodel/fit.py
+++ b/gstools/covmodel/fit.py
@@ -9,8 +9,8 @@ The following classes and functions are provided
 .. autosummary::
    fit_variogram
 """
+# pylint: disable=C0103, W0632
 
-# pylint: disable=C0103
 import numpy as np
 from scipy.optimize import curve_fit
 from gstools.covmodel.tools import check_arg_in_bounds, default_arg_from_bounds
@@ -341,7 +341,7 @@ def _check_vario(model, x_data, y_data):
         raise ValueError(
             "CovModel.fit_variogram: lat-lon models don't support anisotropy."
         )
-    elif model.latlon:
+    if model.latlon:
         # convert to yadrenko model
         x_data = 2 * np.sin(x_data / 2)
     return x_data, y_data, is_dir_vario

--- a/gstools/covmodel/fit.py
+++ b/gstools/covmodel/fit.py
@@ -171,7 +171,6 @@ def fit_variogram(
     )
     # check curve_fit kwargs
     curve_fit_kwargs = {} if curve_fit_kwargs is None else curve_fit_kwargs
-    curve_fit_kwargs.pop("full_output", None)  # no full output (pylint W0632)
     # check method
     if method not in ["trf", "dogbox"]:
         raise ValueError("fit: method needs to be either 'trf' or 'dogbox'")

--- a/gstools/covmodel/fit.py
+++ b/gstools/covmodel/fit.py
@@ -10,7 +10,6 @@ The following classes and functions are provided
    fit_variogram
 """
 # pylint: disable=C0103, W0632
-
 import numpy as np
 from scipy.optimize import curve_fit
 from gstools.covmodel.tools import check_arg_in_bounds, default_arg_from_bounds
@@ -172,6 +171,7 @@ def fit_variogram(
     )
     # check curve_fit kwargs
     curve_fit_kwargs = {} if curve_fit_kwargs is None else curve_fit_kwargs
+    curve_fit_kwargs.pop("full_output", None)  # no full output (pylint W0632)
     # check method
     if method not in ["trf", "dogbox"]:
         raise ValueError("fit: method needs to be either 'trf' or 'dogbox'")

--- a/gstools/covmodel/models.py
+++ b/gstools/covmodel/models.py
@@ -26,7 +26,7 @@ import warnings
 import numpy as np
 from scipy import special as sps
 from gstools.covmodel.tools import AttributeWarning
-from gstools.covmodel import CovModel
+from gstools.covmodel.base import CovModel
 
 __all__ = [
     "Gaussian",

--- a/gstools/covmodel/models.py
+++ b/gstools/covmodel/models.py
@@ -20,8 +20,7 @@ The following classes are provided
    SuperSpherical
    JBessel
 """
-# pylint: disable=C0103, E1101, E1137, R0201
-
+# pylint: disable=C0103, E1101, R0201
 import warnings
 import numpy as np
 from scipy import special as sps

--- a/gstools/covmodel/plot.py
+++ b/gstools/covmodel/plot.py
@@ -24,7 +24,6 @@ The following classes and functions are provided
    plot_spectral_rad_pdf
 """
 # pylint: disable=C0103, C0415, E1130
-
 import numpy as np
 from gstools.tools.geometric import generate_grid
 from gstools.tools.misc import get_fig_ax

--- a/gstools/covmodel/plot.py
+++ b/gstools/covmodel/plot.py
@@ -23,7 +23,8 @@ The following classes and functions are provided
    plot_spectral_density
    plot_spectral_rad_pdf
 """
-# pylint: disable=C0103, C0415
+# pylint: disable=C0103, C0415, E1130
+
 import numpy as np
 from gstools.field.plot import plot_1d, plot_nd
 from gstools.tools.geometric import generate_grid

--- a/gstools/covmodel/plot.py
+++ b/gstools/covmodel/plot.py
@@ -26,7 +26,6 @@ The following classes and functions are provided
 # pylint: disable=C0103, C0415, E1130
 
 import numpy as np
-from gstools.field.plot import plot_1d, plot_nd
 from gstools.tools.geometric import generate_grid
 from gstools.tools.misc import get_fig_ax
 
@@ -53,6 +52,8 @@ __all__ = [
 
 
 def _plot_spatial(dim, pos, field, fig, ax, latlon, **kwargs):
+    from gstools.field.plot import plot_1d, plot_nd
+
     if dim == 1:
         return plot_1d(pos, field, fig, ax, **kwargs)
     return plot_nd(pos, field, "structured", fig, ax, latlon, **kwargs)

--- a/gstools/covmodel/tpl_models.py
+++ b/gstools/covmodel/tpl_models.py
@@ -16,7 +16,7 @@ The following classes and functions are provided
 
 import warnings
 import numpy as np
-from gstools.covmodel import CovModel
+from gstools.covmodel.base import CovModel
 from gstools.covmodel.tools import AttributeWarning
 from gstools.tools.special import (
     tplstable_cor,

--- a/gstools/covmodel/tpl_models.py
+++ b/gstools/covmodel/tpl_models.py
@@ -13,7 +13,6 @@ The following classes and functions are provided
    TPLSimple
 """
 # pylint: disable=C0103, E1101
-
 import warnings
 import numpy as np
 from gstools.covmodel.base import CovModel

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    Field
 """
-# pylint: disable=C0103, W0107, C0415
+# pylint: disable=C0103, C0415
 from functools import partial
 import numpy as np
 from gstools.covmodel.base import CovModel

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    Field
 """
-# pylint: disable=C0103, W0107
+# pylint: disable=C0103, W0107, C0415
 from functools import partial
 import numpy as np
 from gstools.covmodel.base import CovModel

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    Field
 """
-# pylint: disable=C0103
+# pylint: disable=C0103, W0107
 from functools import partial
 import numpy as np
 from gstools.covmodel.base import CovModel
@@ -83,9 +83,8 @@ class Field:
         self.normalizer = normalizer
         self.trend = trend
 
-    def __call__(*args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """Generate the field."""
-        pass
 
     def structured(self, *args, **kwargs):
         """Generate a field on a structured mesh.
@@ -297,9 +296,8 @@ class Field:
                 "Specify 'scalar' or 'vector' before plotting."
             )
 
-        elif self.value_type == "scalar":
+        if self.value_type == "scalar":
             r = plot_field(self, field, fig, ax, **kwargs)
-
         elif self.value_type == "vector":
             if self.model.dim == 2:
                 r = plot_vec_field(self, field, fig, ax, **kwargs)

--- a/gstools/field/cond_srf.py
+++ b/gstools/field/cond_srf.py
@@ -10,7 +10,6 @@ The following classes are provided
    CondSRF
 """
 # pylint: disable=C0103, W0231, W0221, E1102
-
 import numpy as np
 from gstools.field.generator import RandMeth
 from gstools.field.base import Field

--- a/gstools/field/cond_srf.py
+++ b/gstools/field/cond_srf.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    CondSRF
 """
-# pylint: disable=C0103
+# pylint: disable=C0103, W0231, W0221, E1102
 
 import numpy as np
 from gstools.field.generator import RandMeth

--- a/gstools/field/generator.py
+++ b/gstools/field/generator.py
@@ -10,7 +10,7 @@ The following classes are provided
    RandMeth
    IncomprRandMeth
 """
-# pylint: disable=C0103
+# pylint: disable=C0103, W0222
 
 import warnings
 from copy import deepcopy as dcp

--- a/gstools/field/generator.py
+++ b/gstools/field/generator.py
@@ -11,7 +11,6 @@ The following classes are provided
    IncomprRandMeth
 """
 # pylint: disable=C0103, W0222
-
 import warnings
 from copy import deepcopy as dcp
 import numpy as np

--- a/gstools/field/plot.py
+++ b/gstools/field/plot.py
@@ -15,10 +15,14 @@ The following classes and functions are provided
 import numpy as np
 from scipy import interpolate as inter
 from scipy.spatial import ConvexHull
-import matplotlib.pyplot as plt
-from matplotlib.widgets import Slider, RadioButtons
 from gstools.tools.misc import get_fig_ax
 from gstools.tools.geometric import rotation_planes
+
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.widgets import Slider, RadioButtons
+except ImportError as exc:
+    raise ImportError("Plotting: Matplotlib not installed.") from exc
 
 
 __all__ = ["plot_field", "plot_vec_field"]

--- a/gstools/field/plot.py
+++ b/gstools/field/plot.py
@@ -10,7 +10,7 @@ The following classes and functions are provided
    plot_field
    plot_vec_field
 """
-# pylint: disable=C0103
+# pylint: disable=C0103, W0613
 import numpy as np
 from scipy import interpolate as inter
 from scipy.spatial import ConvexHull
@@ -47,12 +47,12 @@ def plot_field(
     **kwargs
         Forwarded to the plotting routine.
     """
-    plot_field = getattr(fld, field)
-    assert not (fld.pos is None or plot_field is None)
+    plt_fld = getattr(fld, field)
+    assert not (fld.pos is None or plt_fld is None)
     if fld.dim == 1:
-        return plot_1d(fld.pos, plot_field, fig, ax, **kwargs)
+        return plot_1d(fld.pos, plt_fld, fig, ax, **kwargs)
     return plot_nd(
-        fld.pos, plot_field, fld.mesh_type, fig, ax, fld.model.latlon, **kwargs
+        fld.pos, plt_fld, fld.mesh_type, fig, ax, fld.model.latlon, **kwargs
     )
 
 
@@ -298,21 +298,21 @@ def plot_vec_field(fld, field="field", fig=None, ax=None):  # pragma: no cover
             "Only structured vector fields are supported "
             "for plotting. Please create one on a structured grid."
         )
-    plot_field = getattr(fld, field)
-    assert not (fld.pos is None or plot_field is None)
+    plt_fld = getattr(fld, field)
+    assert not (fld.pos is None or plt_fld is None)
 
-    norm = np.sqrt(plot_field[0, :].T ** 2 + plot_field[1, :].T ** 2)
+    norm = np.sqrt(plt_fld[0, :].T ** 2 + plt_fld[1, :].T ** 2)
 
     fig, ax = get_fig_ax(fig, ax)
-    title = f"Field 2D {fld.mesh_type}: {plot_field.shape}"
+    title = f"Field 2D {fld.mesh_type}: {plt_fld.shape}"
     x = fld.pos[0]
     y = fld.pos[1]
 
     sp = plt.streamplot(
         x,
         y,
-        plot_field[0, :].T,
-        plot_field[1, :].T,
+        plt_fld[0, :].T,
+        plt_fld[1, :].T,
         color=norm,
         linewidth=norm / 2,
     )
@@ -356,10 +356,10 @@ def _plot_2d(
         if antialias:
             ax.tricontour(x, y, field.ravel(), levels=levels, zorder=-10)
     else:
-        plot_field = field if latlon else field.T
-        cont = ax.contourf(x, y, plot_field, levels=levels)
+        plt_fld = field if latlon else field.T
+        cont = ax.contourf(x, y, plt_fld, levels=levels)
         if antialias:
-            ax.contour(x, y, plot_field, levels=levels, zorder=-10)
+            ax.contour(x, y, plt_fld, levels=levels, zorder=-10)
     ax.set_xlabel(ax_names[0])
     ax.set_ylabel(ax_names[1])
     ax.set_title(title)

--- a/gstools/field/plot.py
+++ b/gstools/field/plot.py
@@ -11,6 +11,7 @@ The following classes and functions are provided
    plot_vec_field
 """
 # pylint: disable=C0103, W0613
+
 import numpy as np
 from scipy import interpolate as inter
 from scipy.spatial import ConvexHull

--- a/gstools/field/plot.py
+++ b/gstools/field/plot.py
@@ -10,7 +10,7 @@ The following classes and functions are provided
    plot_field
    plot_vec_field
 """
-# pylint: disable=C0103, W0613
+# pylint: disable=C0103, W0613, E1101
 
 import numpy as np
 from scipy import interpolate as inter

--- a/gstools/field/plot.py
+++ b/gstools/field/plot.py
@@ -16,7 +16,7 @@ from scipy import interpolate as inter
 from scipy.spatial import ConvexHull
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, RadioButtons
-from gstools.covmodel.plot import _get_fig_ax
+from gstools.tools.misc import get_fig_ax
 from gstools.tools.geometric import rotation_planes
 
 
@@ -81,7 +81,7 @@ def plot_1d(pos, field, fig=None, ax=None, ax_names=None):  # pragma: no cover
     ax : :class:`Axes`
         Axis containing the plot.
     """
-    fig, ax = _get_fig_ax(fig, ax)
+    fig, ax = get_fig_ax(fig, ax)
     title = f"Field 1D: {field.shape}"
     x = pos[0]
     x = x.flatten()
@@ -174,7 +174,7 @@ def plot_nd(
     ax_extents = [ax_ends[p[0]] + ax_ends[p[1]] for p in planes]
     # create figure
     reformat = fig is None and ax is None
-    fig, ax = _get_fig_ax(fig, ax)
+    fig, ax = get_fig_ax(fig, ax)
     ax.set_title(f"Field {dim}D {mesh_type} {field.shape}")
     if reformat:  # only format fig if it was created here
         fig.set_size_inches(8, 5.5 + 0.5 * (dim - 2))
@@ -303,7 +303,7 @@ def plot_vec_field(fld, field="field", fig=None, ax=None):  # pragma: no cover
 
     norm = np.sqrt(plot_field[0, :].T ** 2 + plot_field[1, :].T ** 2)
 
-    fig, ax = _get_fig_ax(fig, ax)
+    fig, ax = get_fig_ax(fig, ax)
     title = f"Field 2D {fld.mesh_type}: {plot_field.shape}"
     x = fld.pos[0]
     y = fld.pos[1]
@@ -347,7 +347,7 @@ def _plot_2d(
     antialias=True,
 ):  # pragma: no cover
     """Plot a 2d field with a contour plot."""
-    fig, ax = _get_fig_ax(fig, ax)
+    fig, ax = get_fig_ax(fig, ax)
     title = f"Field 2D {mesh_type}: {field.shape}"
     ax_names = _ax_names(2, latlon, ax_names=ax_names)
     x, y = pos[::-1] if latlon else pos

--- a/gstools/field/plot.py
+++ b/gstools/field/plot.py
@@ -11,7 +11,6 @@ The following classes and functions are provided
    plot_vec_field
 """
 # pylint: disable=C0103, W0613, E1101
-
 import numpy as np
 from scipy import interpolate as inter
 from scipy.spatial import ConvexHull

--- a/gstools/field/srf.py
+++ b/gstools/field/srf.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    SRF
 """
-# pylint: disable=C0103
+# pylint: disable=C0103, W0221, E1102
 
 import numpy as np
 from gstools.field.generator import RandMeth, IncomprRandMeth

--- a/gstools/field/srf.py
+++ b/gstools/field/srf.py
@@ -10,7 +10,6 @@ The following classes are provided
    SRF
 """
 # pylint: disable=C0103, W0221, E1102
-
 import numpy as np
 from gstools.field.generator import RandMeth, IncomprRandMeth
 from gstools.field.base import Field

--- a/gstools/field/tools.py
+++ b/gstools/field/tools.py
@@ -12,7 +12,6 @@ The following classes and functions are provided
    generate_on_mesh
 """
 # pylint: disable=W0212, C0415
-
 import numpy as np
 import meshio
 

--- a/gstools/field/tools.py
+++ b/gstools/field/tools.py
@@ -11,6 +11,8 @@ The following classes and functions are provided
    to_vtk_helper
    generate_on_mesh
 """
+# pylint: disable=W0212, C0415
+
 import numpy as np
 import meshio
 
@@ -81,9 +83,9 @@ def to_vtk_helper(
                 fields[fieldname + suf[i]] = field[i]
             if filename is None:
                 return to_vtk(f_cls.pos, fields, f_cls.mesh_type)
-            else:
-                return vtk_export(filename, f_cls.pos, fields, f_cls.mesh_type)
-    elif f_cls.value_type == "scalar":
+            return vtk_export(filename, f_cls.pos, fields, f_cls.mesh_type)
+        raise ValueError(f"Field.to_vtk: '{field_select}' not available.")
+    if f_cls.value_type == "scalar":
         if hasattr(f_cls, field_select):
             field = getattr(f_cls, field_select)
         else:
@@ -91,14 +93,11 @@ def to_vtk_helper(
         if not (f_cls.pos is None or field is None or f_cls.mesh_type is None):
             if filename is None:
                 return to_vtk(f_cls.pos, {fieldname: field}, f_cls.mesh_type)
-            else:
-                return vtk_export(
-                    filename, f_cls.pos, {fieldname: field}, f_cls.mesh_type
-                )
-        else:
-            raise ValueError(f"Field.to_vtk: '{field_select}' not available.")
-    else:
-        raise ValueError(f"Unknown field value type: {f_cls.value_type}")
+            return vtk_export(
+                filename, f_cls.pos, {fieldname: field}, f_cls.mesh_type
+            )
+        raise ValueError(f"Field.to_vtk: '{field_select}' not available.")
+    raise ValueError(f"Unknown field value type: {f_cls.value_type}")
 
 
 def generate_on_mesh(
@@ -213,8 +212,8 @@ def generate_on_mesh(
             f_lists = []
             for field in fields:
                 f_list = []
-                for of, le in zip(offset, length):
-                    f_list.append(field[of : of + le])
+                for off, leng in zip(offset, length):
+                    f_list.append(field[off : off + leng])
                 f_lists.append(f_list)
             for f_name, f_list in zip(_names(name, len(f_lists)), f_lists):
                 mesh.cell_data[f_name] = f_list
@@ -239,7 +238,7 @@ def _names(name, cnt):
 
 def _get_select(direction):
     select = []
-    if not (0 < len(direction) < 4):
+    if not 0 < len(direction) < 4:
         raise ValueError(
             f"Field.mesh: need 1 to 3 direction(s), got '{direction}'"
         )

--- a/gstools/field/upscaling.py
+++ b/gstools/field/upscaling.py
@@ -11,7 +11,6 @@ The following functions are provided
    var_no_scaling
 """
 # pylint: disable=W0613
-
 import warnings
 import numpy as np
 

--- a/gstools/field/upscaling.py
+++ b/gstools/field/upscaling.py
@@ -10,6 +10,7 @@ The following functions are provided
    var_coarse_graining
    var_no_scaling
 """
+# pylint: disable=W0613
 
 import warnings
 import numpy as np

--- a/gstools/krige/base.py
+++ b/gstools/krige/base.py
@@ -9,7 +9,7 @@ The following classes are provided
 .. autosummary::
    Krige
 """
-# pylint: disable=C0103
+# pylint: disable=C0103, W0221, E1102, R0201
 import collections
 import numpy as np
 
@@ -378,7 +378,7 @@ class Krige(Field):
             if np.prod(ext_shape) != np.prod(shape):
                 raise ValueError("Krige: wrong number of ext. drift values.")
             return np.array(ext_drift, dtype=np.double).reshape(shape)
-        elif not set_cond and self._cond_ext_drift.size > 0:
+        if not set_cond and self._cond_ext_drift.size > 0:
             raise ValueError("Krige: wrong number of ext. drift values.")
         return np.array([])
 

--- a/gstools/normalizer/base.py
+++ b/gstools/normalizer/base.py
@@ -9,6 +9,7 @@ The following classes are provided
 .. autosummary::
    Normalizer
 """
+# pylint: disable=R0201
 import warnings
 import numpy as np
 import scipy.misc as spm

--- a/gstools/normalizer/methods.py
+++ b/gstools/normalizer/methods.py
@@ -14,6 +14,8 @@ The following classes are provided
    Modulus
    Manly
 """
+# pylint: disable=E1101
+
 import numpy as np
 from gstools.normalizer.base import Normalizer
 

--- a/gstools/normalizer/methods.py
+++ b/gstools/normalizer/methods.py
@@ -15,7 +15,6 @@ The following classes are provided
    Manly
 """
 # pylint: disable=E1101
-
 import numpy as np
 from gstools.normalizer.base import Normalizer
 

--- a/gstools/normalizer/tools.py
+++ b/gstools/normalizer/tools.py
@@ -12,7 +12,7 @@ The following classes and functions are provided
 """
 import numpy as np
 
-from gstools.normalizer import Normalizer
+from gstools.normalizer.base import Normalizer
 from gstools.tools.misc import eval_func
 from gstools.tools.geometric import (
     format_struct_pos_shape,

--- a/gstools/random/rng.py
+++ b/gstools/random/rng.py
@@ -9,8 +9,7 @@ The following classes are provided
 .. autosummary::
    RNG
 """
-# pylint: disable=no-member
-
+# pylint: disable=E1101
 import numpy as np
 import numpy.random as rand
 import emcee as mc

--- a/gstools/random/tools.py
+++ b/gstools/random/tools.py
@@ -88,14 +88,14 @@ def dist_gen(pdf_in=None, cdf_in=None, ppf_in=None, **kwargs):
         if pdf_in is not None and cdf_in is not None:
             return DistPdfCdf(pdf_in, cdf_in, **kwargs)
         raise ValueError("Either pdf or cdf must be given")
-    else:
-        if pdf_in is not None and cdf_in is None:
-            return DistPdfPpf(pdf_in, ppf_in, **kwargs)
-        if pdf_in is None and cdf_in is not None:
-            return DistCdfPpf(cdf_in, ppf_in, **kwargs)
-        if pdf_in is not None and cdf_in is not None:
-            return DistPdfCdfPpf(pdf_in, cdf_in, ppf_in, **kwargs)
-        raise ValueError("pdf or cdf must be given along with the ppf")
+
+    if pdf_in is not None and cdf_in is None:
+        return DistPdfPpf(pdf_in, ppf_in, **kwargs)
+    if pdf_in is None and cdf_in is not None:
+        return DistCdfPpf(cdf_in, ppf_in, **kwargs)
+    if pdf_in is not None and cdf_in is not None:
+        return DistPdfCdfPpf(pdf_in, cdf_in, ppf_in, **kwargs)
+    raise ValueError("pdf or cdf must be given along with the ppf")
 
 
 class DistPdf(rv_continuous):

--- a/gstools/tools/export.py
+++ b/gstools/tools/export.py
@@ -15,7 +15,6 @@ The following functions are provided
    to_vtk_unstructured
 """
 # pylint: disable=C0103, E1101
-
 import numpy as np
 from pyevtk.hl import gridToVTK, pointsToVTK
 

--- a/gstools/tools/geometric.py
+++ b/gstools/tools/geometric.py
@@ -30,7 +30,6 @@ The following functions are provided
    chordal_to_great_circle
 """
 # pylint: disable=C0103
-
 import numpy as np
 
 __all__ = [

--- a/gstools/tools/misc.py
+++ b/gstools/tools/misc.py
@@ -26,12 +26,12 @@ def get_fig_ax(fig=None, ax=None, ax_name="rectilinear"):  # pragma: no cover
 
     Parameters
     ----------
-    fig : figure or None
+    fig : figure or :any:`None`
         desired figure.
-    ax : axis or None
+    ax : axis or :any:`None`
         desired axis.
-    ax_name : TYPE, optional
-        Axis name. The default is "rectilinear".
+    ax_name : :class:`str`, optional
+        Axis type name. The default is "rectilinear".
 
     Returns
     -------

--- a/gstools/tools/misc.py
+++ b/gstools/tools/misc.py
@@ -12,7 +12,6 @@ The following functions are provided
    eval_func
 """
 # pylint: disable=C0103, C0415
-
 import numpy as np
 from gstools.tools.geometric import format_struct_pos_dim, generate_grid
 

--- a/gstools/tools/misc.py
+++ b/gstools/tools/misc.py
@@ -7,6 +7,7 @@ GStools subpackage providing miscellaneous tools.
 The following functions are provided
 
 .. autosummary::
+   get_fig_ax
    list_format
    eval_func
 """
@@ -14,7 +15,43 @@ import numpy as np
 from gstools.tools.geometric import format_struct_pos_dim, generate_grid
 
 
-__all__ = ["list_format", "eval_func"]
+__all__ = ["get_fig_ax", "list_format", "eval_func"]
+
+
+def get_fig_ax(fig=None, ax=None, ax_name="rectilinear"):  # pragma: no cover
+    """
+    Get correct matplotlib figure and axes.
+
+    Parameters
+    ----------
+    fig : figure or None
+        desired figure.
+    ax : axis or None
+        desired axis.
+    ax_name : TYPE, optional
+        Axis name. The default is "rectilinear".
+
+    Returns
+    -------
+    fig : figure
+        desired figure.
+    ax : axis
+        desired axis.
+    """
+    from matplotlib import pyplot as plt
+
+    if fig is None and ax is None:
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection=ax_name)
+    elif ax is None:
+        ax = fig.add_subplot(111, projection=ax_name)
+    elif fig is None:
+        fig = ax.get_figure()
+        assert ax.name == ax_name
+    else:
+        assert ax.name == ax_name
+        assert ax.get_figure() == fig
+    return fig, ax
 
 
 def list_format(lst, prec):  # pragma: no cover

--- a/gstools/tools/misc.py
+++ b/gstools/tools/misc.py
@@ -11,6 +11,8 @@ The following functions are provided
    list_format
    eval_func
 """
+# pylint: disable=C0103, C0415
+
 import numpy as np
 from gstools.tools.geometric import format_struct_pos_dim, generate_grid
 

--- a/gstools/tools/misc.py
+++ b/gstools/tools/misc.py
@@ -40,7 +40,10 @@ def get_fig_ax(fig=None, ax=None, ax_name="rectilinear"):  # pragma: no cover
     ax : axis
         desired axis.
     """
-    from matplotlib import pyplot as plt
+    try:
+        from matplotlib import pyplot as plt
+    except ImportError as exc:
+        raise ImportError("Plotting: Matplotlib not installed.") from exc
 
     if fig is None and ax is None:
         fig = plt.figure()

--- a/gstools/tools/special.py
+++ b/gstools/tools/special.py
@@ -15,7 +15,6 @@ The following functions are provided
    tpl_gau_spec_dens
 """
 # pylint: disable=C0103, E1101
-
 import numpy as np
 from scipy import special as sps
 

--- a/gstools/transform/field.py
+++ b/gstools/transform/field.py
@@ -17,10 +17,8 @@ The following functions are provided
    normal_to_arcsin
    normal_to_uquad
 """
-# pylint: disable=C0103, E1101
-
+# pylint: disable=C0103
 from warnings import warn
-
 import numpy as np
 from scipy.special import erf, erfinv
 

--- a/gstools/variogram/binning.py
+++ b/gstools/variogram/binning.py
@@ -9,8 +9,6 @@ The following functions are provided
 .. autosummary::
    standard_bins
 """
-# pylint: disable=C0103
-
 import numpy as np
 
 from gstools.tools.geometric import (

--- a/gstools/variogram/variogram.py
+++ b/gstools/variogram/variogram.py
@@ -10,8 +10,6 @@ The following functions are provided
    vario_estimate
    vario_estimate_axis
 """
-# pylint: disable=C0103
-
 import numpy as np
 
 from gstools.tools.geometric import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,23 +14,6 @@ write_to_template = "__version__ = '{version}'"
 local_scheme = "no-local-version"
 fallback_version = "0.0.0.dev0"
 
-[tool.coverage.run]
-source = ["gstools"]
-omit = [
-    "*docs*",
-    "*examples*",
-    "*tests*",
-    "*/gstools/covmodel/plot.py",
-    "*/gstools/field/plot.py",
-]
-
-[tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    "def __repr__",
-    "def __str__",
-]
-
 [tool.black]
 line-length = 79
 target-version = [
@@ -38,3 +21,46 @@ target-version = [
     "py37",
     "py38",
 ]
+
+[tool.coverage]
+    [tool.coverage.run]
+    source = ["gstools"]
+    omit = [
+        "*docs*",
+        "*examples*",
+        "*tests*",
+        "*/gstools/covmodel/plot.py",
+        "*/gstools/field/plot.py",
+    ]
+
+    [tool.coverage.report]
+    exclude_lines = [
+        "pragma: no cover",
+        "def __repr__",
+        "def __str__",
+    ]
+
+[tool.pylint]
+    [tool.pylint.master]
+    extension-pkg-whitelist = [
+        "numpy",
+        "scipy",
+        "ConvexHull",
+    ]
+    ignore = "_version.py"
+
+    [tool.pylint.message_control]
+    disable = [
+        "R0801",
+    ]
+
+    [tool.pylint.reports]
+    output-format = "colorized"
+
+    [tool.pylint.design]
+    max-args = 20
+    max-locals = 50
+    max-branches = 30
+    max-statements = 80
+    max-attributes = 25
+    max-public-methods = 75

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ target-version = [
     extension-pkg-whitelist = [
         "numpy",
         "scipy",
-        "ConvexHull",
     ]
     ignore = "_version.py"
 


### PR DESCRIPTION
... I've done it. Pylint is a pain, but a good one.

I created a setup for Pylint in `pyproject.toml` that should warn us about bad practice. I added a new stage in CI to check pylint.

Certain Pylint rules are disabled per file, where it makes sence (at least for me).

It helped me figure out all of the circular imports (see #24). Especially the matplotlib imports are now in a try block and later on deferred.

All remaining pylint warnings were sorted out here.
