### PR TITLE
build: use oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "setuptools_scm[toml]>=3.5",
-    "numpy>=1.14.5,<2.0",
+    "oldest-supported-numpy",
     "Cython>=0.28.3,<3.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Closes #164 

Use the meta package for numpy as a build dep: https://github.com/scipy/oldest-supported-numpy

See:
https://scikit-hep.org/developer/packaging#special-additions-numpy

The reason to use the oldest available Numpy version as a build-time dependency is because of ABI compatibility. Binaries compiled with old Numpy versions are binary compatible with newer Numpy versions, but not vice versa.