### PR TITLE
[Bug-Fix] Dependency updates (emcee v3.1, Pylint v2.9)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: black check
         run: |
-          python -m black --check .
+          python -m black --check --diff --color .
 
       - name: pylint check
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black pylint
+          pip install black 'pylint<3'
           pip install --editable .
 
       - name: black check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to **GSTools** will be documented in this file.
 
 ### Bugfixes
 - `vario_estimate` was altering the input field unter certain circumstances [#180](https://github.com/GeoStat-Framework/GSTools/issues/180)
+- `emcee` v3.1 now requires `nsteps` in `run_mcmc()` to be integer (called in `RNG.sample_ln_pdf`) [#184](https://github.com/GeoStat-Framework/GSTools/pull/184)
 
 
 ## [1.3.1] - Pure Pink - 2021-06

--- a/gstools/covmodel/base.py
+++ b/gstools/covmodel/base.py
@@ -212,11 +212,10 @@ class CovModel:
         cls.__doc__ += CovModel.__doc__[45:]
         # overridden functions get standard doc if no new doc was created
         ign = ["__", "variogram", "covariance", "cor"]
-        for att in cls.__dict__:
+        for att, attr_cls in cls.__dict__.items():
             if any(att.startswith(i) for i in ign) or att not in dir(CovModel):
                 continue
             attr_doc = getattr(CovModel, att).__doc__
-            attr_cls = cls.__dict__[att]
             if attr_cls.__doc__ is None:
                 attr_cls.__doc__ = attr_doc
 

--- a/gstools/covmodel/tools.py
+++ b/gstools/covmodel/tools.py
@@ -412,30 +412,30 @@ def set_arg_bounds(model, check_args=True, **kwargs):
     """
     # if variance needs to be resetted, do this at last
     var_bnds = []
-    for arg in kwargs:
-        if not check_bounds(kwargs[arg]):
+    for arg, bounds in kwargs.items():
+        if not check_bounds(bounds):
             raise ValueError(
                 "Given bounds for '{0}' are not valid, got: {1}".format(
-                    arg, kwargs[arg]
+                    arg, bounds
                 )
             )
         if arg in model.opt_arg:
-            model._opt_arg_bounds[arg] = kwargs[arg]
+            model._opt_arg_bounds[arg] = bounds
         elif arg == "var":
-            var_bnds = kwargs[arg]
+            var_bnds = bounds
             continue
         elif arg == "len_scale":
-            model.len_scale_bounds = kwargs[arg]
+            model.len_scale_bounds = bounds
         elif arg == "nugget":
-            model.nugget_bounds = kwargs[arg]
+            model.nugget_bounds = bounds
         elif arg == "anis":
-            model.anis_bounds = kwargs[arg]
+            model.anis_bounds = bounds
         else:
             raise ValueError(
                 "set_arg_bounds: unknown argument '{}'".format(arg)
             )
         if check_args and check_arg_in_bounds(model, arg) > 0:
-            def_arg = default_arg_from_bounds(kwargs[arg])
+            def_arg = default_arg_from_bounds(bounds)
             if arg == "anis":
                 setattr(model, arg, [def_arg] * (model.dim - 1))
             else:

--- a/gstools/random/rng.py
+++ b/gstools/random/rng.py
@@ -78,6 +78,8 @@ class RNG:
             sample_size = burn_in
         else:
             sample_size = max(burn_in, (size / nwalkers) * oversampling_factor)
+        # sample_size needs to be integer for emcee >= 3.1
+        sample_size = int(sample_size)
         # initial guess
         init_guess = (
             self.random.rand(nwalkers).reshape((nwalkers, 1)) * sample_around

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ packages = find:
 install_requires =
     emcee>=3.0.0,<4
     hankel>=1.0.2,<2
-    meshio>=4.0.3,<5.0
+    meshio>=4.0.3,<5
     numpy>=1.14.5,<2
     pyevtk>=1.1.1,<2
     scipy>=1.1.0,<2
@@ -54,19 +54,19 @@ exclude =
 
 [options.extras_require]
 doc =
-    m2r2
-    matplotlib>=3
-    meshzoo
-    numpydoc>=1.1
-    pykrige>=1.5
-    pyvista
-    sphinx>=3
-    sphinx-gallery>=0.8
-    sphinx-rtd-theme>=0.5
+    m2r2>=0.2.8,<1
+    matplotlib>=3,<4
+    meshzoo>=0.7,<1
+    numpydoc>=1.1,<2
+    pykrige>=1.5,<2
+    pyvista>=0.31,<1
+    sphinx>=3,<4
+    sphinx-gallery>=0.8,<1
+    sphinx-rtd-theme>=0.5,<1
 plotting =
-    matplotlib
-    pyvista
+    matplotlib>=3,<4
+    pyvista>=0.29,<1
 test =
-    coverage[toml]>=5.2.1
-    pytest>=6.0
-    pytest-cov>=2.11.0
+    coverage[toml]>=5.2.1,<6
+    pytest>=6.0,<7
+    pytest-cov>=2.11.0,<3


### PR DESCRIPTION
Closes #183 

- `sampler.run_mcmc()` needs `nsteps` as integer since `emcee v3.1` (#183)
- PyLint C0206 was added with v2.9
- all dependencies have fixed major version now
- minor tweak in CI to better show the complains of black if there are any 