### PR TITLE
Krige: filter out nan values from cond_val

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to **GSTools** will be documented in this file.
 ### Enhancements
 See: [#197](https://github.com/GeoStat-Framework/GSTools/issues/197)
 - `gstools.transform`:
-  - add keywords `field`, `store` and `process` keyword to all transformations to control storage and respect `normalizer`
+  - add keywords `field`, `store`, `process` and `keep_mean` to all transformations to control storage and respect `normalizer`
   - added `apply_function` transformation
   - added `apply` as wrapper for all transformations
   - added `transform` method to all `Field` (sub)classes as interface to `transform.apply`
@@ -26,6 +26,7 @@ See: [#197](https://github.com/GeoStat-Framework/GSTools/issues/197)
 - performance improvement by using `np.asarray` instead of `np.array` where possible
 - updated examples to use new features
 - added incomplete lower gamma function `inc_gamma_low` (for TPLGaussian spectral density)
+- filter `nan` values from `cond_val` array in all kriging routines [#201](https://github.com/GeoStat-Framework/GSTools/issues/201)
 
 ### Bugfixes
 - `inc_gamma` was defined wrong for integer `s < 0`

--- a/gstools/krige/base.py
+++ b/gstools/krige/base.py
@@ -48,7 +48,7 @@ class Krige(Field):
     cond_pos : :class:`list`
         tuple, containing the given condition positions (x, [y, z])
     cond_val : :class:`numpy.ndarray`
-        the values of the conditions
+        the values of the conditions (nan values will be ignored)
     drift_functions : :class:`list` of :any:`callable`, :class:`str` or :class:`int`
         Either a list of callable functions, an integer representing
         the polynomial order of the drift or one of the following strings:
@@ -469,7 +469,8 @@ class Krige(Field):
         cond_pos : :class:`list`, optional
             the position tuple of the conditions (x, [y, z]). Default: current.
         cond_val : :class:`numpy.ndarray`, optional
-            the values of the conditions. Default: current.
+            the values of the conditions (nan values will be ignored).
+            Default: current.
         ext_drift : :class:`numpy.ndarray` or :any:`None`, optional
             the external drift values at the given conditions (only for EDK)
             For multiple external drifts, the first dimension

--- a/gstools/krige/methods.py
+++ b/gstools/krige/methods.py
@@ -32,7 +32,7 @@ class Simple(Krige):
     cond_pos : :class:`list`
         tuple, containing the given condition positions (x, [y, z])
     cond_val : :class:`numpy.ndarray`
-        the values of the conditions
+        the values of the conditions (nan values will be ignored)
     mean : :class:`float`, optional
         mean value used to shift normalized conditioning data.
         Could also be a callable. The default is None.
@@ -130,7 +130,7 @@ class Ordinary(Krige):
     cond_pos : :class:`list`
         tuple, containing the given condition positions (x, [y, z])
     cond_val : :class:`numpy.ndarray`
-        the values of the conditions
+        the values of the conditions (nan values will be ignored)
     normalizer : :any:`None` or :any:`Normalizer`, optional
         Normalizer to be applied to the input data to gain normality.
         The default is None.
@@ -228,7 +228,7 @@ class Universal(Krige):
     cond_pos : :class:`list`
         tuple, containing the given condition positions (x, [y, z])
     cond_val : :class:`numpy.ndarray`
-        the values of the conditions
+        the values of the conditions (nan values will be ignored)
     drift_functions : :class:`list` of :any:`callable`, :class:`str` or :class:`int`
         Either a list of callable functions, an integer representing
         the polynomial order of the drift or one of the following strings:
@@ -335,7 +335,7 @@ class ExtDrift(Krige):
     cond_pos : :class:`list`
         tuple, containing the given condition positions (x, [y, z])
     cond_val : :class:`numpy.ndarray`
-        the values of the conditions
+        the values of the conditions (nan values will be ignored)
     ext_drift : :class:`numpy.ndarray`
         the external drift values at the given condition positions.
     normalizer : :any:`None` or :any:`Normalizer`, optional
@@ -441,7 +441,7 @@ class Detrended(Krige):
     cond_pos : :class:`list`
         tuple, containing the given condition positions (x, [y, z])
     cond_val : :class:`numpy.ndarray`
-        the values of the conditions
+        the values of the conditions (nan values will be ignored)
     trend_function : :any:`callable`
         The callable trend function. Should have the signiture: f(x, [y, z])
     exact : :class:`bool`, optional

--- a/gstools/krige/tools.py
+++ b/gstools/krige/tools.py
@@ -27,7 +27,7 @@ def set_condition(cond_pos, cond_val, dim):
     cond_pos : :class:`list`
         the position tuple of the conditions (x, [y, z])
     cond_val : :class:`numpy.ndarray`
-        the values of the conditions
+        the values of the conditions (nan values will be ignored)
     dim : :class:`int`, optional
         Spatial dimension
 
@@ -39,9 +39,9 @@ def set_condition(cond_pos, cond_val, dim):
     Returns
     -------
     cond_pos : :class:`list`
-        the error checked cond_pos
+        the error checked cond_pos with all finite values
     cond_val : :class:`numpy.ndarray`
-        the error checked cond_val
+        the error checked cond_val for all finite cond_pos values
     """
     # convert the input for right shapes and dimension checks
     cond_val = np.asarray(cond_val, dtype=np.double).reshape(-1)
@@ -51,7 +51,8 @@ def set_condition(cond_pos, cond_val, dim):
             "Please check your 'cond_pos' and 'cond_val' parameters. "
             "The shapes do not match."
         )
-    return cond_pos, cond_val
+    mask = np.isfinite(cond_val)
+    return cond_pos[:, mask], cond_val[mask]
 
 
 def get_drift_functions(dim, drift_type):


### PR DESCRIPTION
Since the variogram estimation routines ignore nan-data as well as the normalizers, kriging should do that, too.