### PR TITLE
Pylint: use f-strings where possible

### DIFF
--- a/gstools/covmodel/tools.py
+++ b/gstools/covmodel/tools.py
@@ -269,7 +269,7 @@ def check_bounds(bounds):
 def check_arg_in_bounds(model, arg, val=None):
     """Check if given argument value is in bounds of the given model."""
     if arg not in model.arg_bounds:
-        raise ValueError("check bounds: unknown argument: {}".format(arg))
+        raise ValueError(f"check bounds: unknown argument: {arg}")
     bnd = list(model.arg_bounds[arg])
     val = getattr(model, arg) if val is None else val
     val = np.asarray(val)
@@ -417,9 +417,7 @@ def set_arg_bounds(model, check_args=True, **kwargs):
     for arg, bounds in kwargs.items():
         if not check_bounds(bounds):
             raise ValueError(
-                "Given bounds for '{0}' are not valid, got: {1}".format(
-                    arg, bounds
-                )
+                f"Given bounds for '{arg}' are not valid, got: {bounds}"
             )
         if arg in model.opt_arg:
             model._opt_arg_bounds[arg] = bounds
@@ -433,9 +431,7 @@ def set_arg_bounds(model, check_args=True, **kwargs):
         elif arg == "anis":
             model.anis_bounds = bounds
         else:
-            raise ValueError(
-                "set_arg_bounds: unknown argument '{}'".format(arg)
-            )
+            raise ValueError(f"set_arg_bounds: unknown argument '{arg}'")
         if check_args and check_arg_in_bounds(model, arg) > 0:
             def_arg = default_arg_from_bounds(bounds)
             if arg == "anis":
@@ -471,21 +467,13 @@ def check_arg_bounds(model):
         val = getattr(model, arg)
         error_case = check_arg_in_bounds(model, arg)
         if error_case == 1:
-            raise ValueError(
-                "{0} needs to be >= {1}, got: {2}".format(arg, bnd[0], val)
-            )
+            raise ValueError(f"{arg} needs to be >= {bnd[0]}, got: {val}")
         if error_case == 2:
-            raise ValueError(
-                "{0} needs to be > {1}, got: {2}".format(arg, bnd[0], val)
-            )
+            raise ValueError(f"{arg} needs to be > {bnd[0]}, got: {val}")
         if error_case == 3:
-            raise ValueError(
-                "{0} needs to be <= {1}, got: {2}".format(arg, bnd[1], val)
-            )
+            raise ValueError(f"{arg} needs to be <= {bnd[1]}, got: {val}")
         if error_case == 4:
-            raise ValueError(
-                "{0} needs to be < {1}, got: {2}".format(arg, bnd[1], val)
-            )
+            raise ValueError(f"{arg} needs to be < {bnd[1]}, got: {val}")
 
 
 def set_dim(model, dim):

--- a/gstools/field/base.py
+++ b/gstools/field/base.py
@@ -692,9 +692,7 @@ class Field:
             dim_str = f"dim={self.dim}"
         else:
             dim_str = f"model={self.model.name}"
-        return "{0}({1}, value_type='{2}'{3})".format(
-            self.name,
-            dim_str,
-            self.value_type,
-            self._fmt_mean_norm_trend(),
+        return (
+            f"{self.name}({dim_str}, "
+            f"value_type='{self.value_type}'{self._fmt_mean_norm_trend()})"
         )

--- a/gstools/field/cond_srf.py
+++ b/gstools/field/cond_srf.py
@@ -303,6 +303,6 @@ class CondSRF(Field):
 
     def __repr__(self):
         """Return String representation."""
-        return "{0}(krige={1}, generator={2})".format(
-            self.name, self.krige, self.generator.name
+        return (
+            f"{self.name}(krige={self.krige}, generator={self.generator.name})"
         )

--- a/gstools/field/generator.py
+++ b/gstools/field/generator.py
@@ -316,8 +316,9 @@ class RandMeth:
 
     def __repr__(self):
         """Return String representation."""
-        return "RandMeth(model={0}, mode_no={1}, seed={2})".format(
-            self.model, self._mode_no, self.seed
+        return (
+            f"{self.name}(model={self.model}, "
+            f"mode_no={self._mode_no}, seed={self.seed})"
         )
 
 

--- a/gstools/field/srf.py
+++ b/gstools/field/srf.py
@@ -209,9 +209,7 @@ class SRF(Field):
 
     def __repr__(self):
         """Return String representation."""
-        return "{0}(model={1}{2}, generator={3})".format(
-            self.name,
-            self.model.name,
-            self._fmt_mean_norm_trend(),
-            self.generator.name,
+        return (
+            f"{self.name}(model={self.model.name}"
+            f"{self._fmt_mean_norm_trend()}, generator={self.generator.name})"
         )

--- a/gstools/field/tools.py
+++ b/gstools/field/tools.py
@@ -29,7 +29,7 @@ def _fmt_func_val(f_cls, func_val):  # pragma: no cover
         return "<function>"  # or format(func_val.__name__)
     if np.size(func_val) > 1:
         return list_format(func_val, prec=f_cls.model._prec)
-    return "{0:.{p}}".format(float(func_val), p=f_cls.model._prec)
+    return f"{float(func_val):.{f_cls.model._prec}}"
 
 
 def _fmt_normalizer(f_cls):  # pragma: no cover

--- a/gstools/krige/base.py
+++ b/gstools/krige/base.py
@@ -702,9 +702,7 @@ class Krige(Field):
 
     def __repr__(self):
         """Return String representation."""
-        return "{0}(model={1}, cond_no={2}{3})".format(
-            self.name,
-            self.model.name,
-            self.cond_no,
-            self._fmt_mean_norm_trend(),
+        return (
+            f"{self.name}(model={self.model.name}, "
+            f"cond_no={self.cond_no}{self._fmt_mean_norm_trend()})"
         )

--- a/gstools/normalizer/base.py
+++ b/gstools/normalizer/base.py
@@ -76,10 +76,10 @@ class Normalizer:
             dat_in = np.logical_and(data > data_range[0], data < data_range[1])
             if not np.all(dat_in):
                 warnings.warn(
-                    "{0}: data (min: {1}, max: {2}) out of range: {3}. "
-                    "Affected values will be treated as NaN.".format(
-                        self.name, np.min(data), np.max(data), data_range
-                    )
+                    f"{self.name}: "
+                    f"data (min: {np.min(data)}, max: {np.max(data)}) "
+                    f"out of range: {data_range}. "
+                    "Affected values will be treated as NaN."
                 )
                 is_data[is_data] &= dat_in
                 data = data[dat_in]
@@ -254,7 +254,7 @@ class Normalizer:
     def __repr__(self):
         """Return String representation."""
         para_strs = [
-            "{0}={1:.{2}}".format(p, float(getattr(self, p)), self._prec)
+            f"{p}={float(getattr(self, p)):.{self._prec}}"
             for p in sorted(self.default_parameter)
         ]
         return f"{self.name}({', '.join(para_strs)})"


### PR DESCRIPTION
Pylint 2.11 added a checker for f-strings (https://github.com/PyCQA/pylint/pull/4796).
Since we only support python >= 3.6 we should use f-strings where possible.