### PR TITLE
Remove deprecated scipy method pinv2

### DIFF
--- a/src/gstools/krige/base.py
+++ b/src/gstools/krige/base.py
@@ -35,7 +35,7 @@ else:
 __all__ = ["Krige"]
 
 
-P_INV = {"pinv": spl.pinv, "pinv2": spl.pinv2, "pinvh": spl.pinvh}
+P_INV = {"pinv": spl.pinv, "pinvh": spl.pinvh}
 """dict: Standard pseudo-inverse routines"""
 
 
@@ -103,8 +103,7 @@ class Krige(Field):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,

--- a/src/gstools/krige/methods.py
+++ b/src/gstools/krige/methods.py
@@ -67,8 +67,7 @@ class Simple(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -162,8 +161,7 @@ class Ordinary(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -267,8 +265,7 @@ class Universal(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -369,8 +366,7 @@ class ExtDrift(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -464,8 +460,7 @@ class Detrended(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,


### PR DESCRIPTION
With Scipy v1.9 GSTools fails to import `pinv2`, as reported in #246 .

According to the [PR](https://github.com/scipy/scipy/pull/13831) both methods `pinv` and `pinv2` have been using the same algorithms for a long time. Thus, I simply deleted the option `pinv2`.