### PR TITLE
Change float comparison in tests

### DIFF
--- a/src/gstools/krige/base.py
+++ b/src/gstools/krige/base.py
@@ -35,7 +35,7 @@ else:
 __all__ = ["Krige"]
 
 
-P_INV = {"pinv": spl.pinv, "pinv2": spl.pinv2, "pinvh": spl.pinvh}
+P_INV = {"pinv": spl.pinv, "pinvh": spl.pinvh}
 """dict: Standard pseudo-inverse routines"""
 
 
@@ -103,8 +103,7 @@ class Krige(Field):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,

--- a/src/gstools/krige/methods.py
+++ b/src/gstools/krige/methods.py
@@ -67,8 +67,7 @@ class Simple(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -162,8 +161,7 @@ class Ordinary(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -267,8 +265,7 @@ class Universal(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -369,8 +366,7 @@ class ExtDrift(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,
@@ -464,8 +460,7 @@ class Detrended(Krige):
     pseudo_inv_type : :class:`str` or :any:`callable`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinv"`: use `pinv` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         If you want to use another routine to invert the kriging matrix,

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -172,9 +172,7 @@ class TestTransform(unittest.TestCase):
             store="f2",
             process=True,
         )
-        np.testing.assert_allclose(
-            np.unique(np.log(srf.f2)), [-1.0, 0.0, 1.0]
-        )
+        np.testing.assert_allclose(np.unique(np.log(srf.f2)), [-1.0, 0.0, 1.0])
 
         values = [-1, 0, 0.5, 1]
         srf.transform(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -63,19 +63,19 @@ class TestTransform(unittest.TestCase):
         srf.transform(
             "discrete", values=values, thresholds=thresholds, store="f1"
         )
-        np.testing.assert_array_equal(np.unique(srf.f1), [-1, 0, 1])
+        np.testing.assert_allclose(np.unique(srf.f1), [-1, 0, 1])
 
         values = [-1, 0, 1]
         srf.transform(
             "discrete", values=values, thresholds="arithmetic", store="f2"
         )
-        np.testing.assert_array_equal(np.unique(srf.f2), [-1.0, 0.0, 1.0])
+        np.testing.assert_allclose(np.unique(srf.f2), [-1.0, 0.0, 1.0])
 
         values = [-1, 0, 0.5, 1]
         srf.transform(
             "discrete", values=values, thresholds="equal", store="f3"
         )
-        np.testing.assert_array_equal(np.unique(srf.f3), values)
+        np.testing.assert_allclose(np.unique(srf.f3), values)
         # checks
         with self.assertRaises(ValueError):
             srf.transform("discrete", values=values, thresholds=[1])
@@ -84,7 +84,7 @@ class TestTransform(unittest.TestCase):
 
         # function
         srf.transform("function", function=lambda x: 2 * x, store="f4")
-        np.testing.assert_array_equal(2 * srf.field, srf.f4)
+        np.testing.assert_allclose(2 * srf.field, srf.f4)
         with self.assertRaises(ValueError):
             srf.transform("function", function=None)
 
@@ -162,7 +162,7 @@ class TestTransform(unittest.TestCase):
             store="f1",
             process=True,
         )
-        np.testing.assert_array_equal(np.unique(np.log(srf.f1)), [-1, 0, 1])
+        np.testing.assert_allclose(np.unique(np.log(srf.f1)), [-1, 0, 1])
 
         values = [-1, 0, 1]
         srf.transform(
@@ -172,7 +172,7 @@ class TestTransform(unittest.TestCase):
             store="f2",
             process=True,
         )
-        np.testing.assert_array_equal(
+        np.testing.assert_allclose(
             np.unique(np.log(srf.f2)), [-1.0, 0.0, 1.0]
         )
 
@@ -184,7 +184,7 @@ class TestTransform(unittest.TestCase):
             store="f3",
             process=True,
         )
-        np.testing.assert_array_equal(np.unique(np.log(srf.f3)), values)
+        np.testing.assert_allclose(np.unique(np.log(srf.f3)), values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some tests are failing in PR #247 due to very small discrepancies (~10e-16) in floating point comparisons. An approximate comparison is the better test.