### PR TITLE
pykrige: fix passed variogram in case of geo-coord

### DIFF
--- a/src/gstools/covmodel/base.py
+++ b/src/gstools/covmodel/base.py
@@ -321,9 +321,11 @@ class CovModel:
 
     # pykrige functions
 
-    def pykrige_vario(self, args=None, r=0):
+    def pykrige_vario(self, args=None, r=0):  # pragma: no cover
         """Isotropic variogram of the model for pykrige."""
-        return self.variogram(r)  # pragma: no cover
+        if self.latlon:
+            return self.vario_yadrenko(np.deg2rad(r))
+        return self.variogram(r)
 
     @property
     def pykrige_anis(self):


### PR DESCRIPTION
PyKrige was not able to use geographical coordinates with a GSTools CovModel. This is the GSTools part of the fix.

See: https://github.com/GeoStat-Framework/PyKrige/issues/217 and https://github.com/GeoStat-Framework/GSTools/issues/235
