### PR TITLE
Add Python 3.11 and git-archive support

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_ARCHS: ${{ matrix.cfg.arch }}
         with:
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.7
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
 requires = [
-    "setuptools>=62",
-    "wheel",
-    "setuptools_scm[toml]>=6.4",
+    "setuptools>=64",
+    "setuptools_scm>=7",
     "oldest-supported-numpy",
-    "Cython>=0.28.3,<3.0",
-    "extension-helpers",
+    "Cython>=0.29.32,<3.0",
+    "extension-helpers>=1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -14,9 +13,6 @@ requires-python = ">=3.7"
 name = "gstools"
 description = "GSTools: A geostatistical toolbox."
 authors = [
-    {name = "Sebastian Müller, Lennart Schüler", email = "info@geostat-framework.org"},
-]
-maintainers = [
     {name = "Sebastian Müller, Lennart Schüler", email = "info@geostat-framework.org"},
 ]
 readme = "README.md"
@@ -40,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Scientific/Engineering :: Hydrology",
@@ -101,9 +98,11 @@ line_length = 79
 [tool.black]
 line-length = 79
 target-version = [
-    "py36",
     "py37",
     "py38",
+    "py39",
+    "py310",
+    "py311",
 ]
 
 [tool.coverage]
@@ -155,8 +154,8 @@ target-version = [
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
-# Disable building PyPy wheels on all platforms, 32bit for py3.10 and musllinux builds, py3.6
-skip = ["cp36-*", "pp*", "cp310-win32", "cp310-manylinux_i686", "*-musllinux_*"]
+# Disable building PyPy wheels on all platforms, 32bit for py3.10/11 and musllinux builds, py3.6
+skip = ["cp36-*", "pp*", "cp31*-win32", "cp31*-manylinux_i686", "*-musllinux_*"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"


### PR DESCRIPTION
- update build requirements
- add CI builds/tests for python 3.11
- setuptools_scm v7: add [archive support](https://github.com/pypa/setuptools_scm#builtin-mechanisms-for-obtaining-version-numbers)
- update readthedocs python version to 3.8