### PR TITLE
Field.plot: solve long-standing mpl slider bug

### DIFF
--- a/src/gstools/field/plot.py
+++ b/src/gstools/field/plot.py
@@ -254,7 +254,6 @@ def plot_nd(
             s.valstep = ax_steps[i]
             s.ax.set_xlim(*ax_ends[i])
             # update representation
-            s.poly.xy[:2] = (s.valmin, 0), (s.valmin, 1)
             s.vline.set_data(2 * [s.valinit], [-0.1, 1.1])
             s.reset()
         im.set_extent(ax_extents[p])


### PR DESCRIPTION
We had a long standing bug in the used matplotlib sliders in the nD viewers as seen here:
https://geostat-framework.readthedocs.io/projects/gstools/en/v1.4.0/examples/01_random_field/07_higher_dimensions.html