### PR TITLE
Remove unnecessary coding, use a few f-strings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # GeoStatTools documentation build configuration file, created by
 # sphinx-quickstart on Fri Jan  5 14:20:43 2018.
@@ -111,7 +110,7 @@ master_doc = "contents"
 # General information about the project.
 curr_year = datetime.datetime.now().year
 project = "GSTools"
-copyright = "2018 - {}, Sebastian Müller, Lennart Schüler".format(curr_year)
+copyright = f"2018 - {curr_year}, Sebastian Müller, Lennart Schüler"
 author = "Sebastian Müller, Lennart Schüler"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/examples/00_misc/02_check_rand_meth_sampling.py
+++ b/examples/00_misc/02_check_rand_meth_sampling.py
@@ -57,7 +57,7 @@ def plot_rand_meth_samples(generator):
     sample_in = np.sum(rad <= np.max(x))
     ax.hist(rad[rad <= np.max(x)], bins=sample_in // 50, density=True)
     ax.set_xlim([0, np.max(x)])
-    ax.set_title("Radius samples shown {}/{}".format(sample_in, len(rad)))
+    ax.set_title(f"Radius samples shown {sample_in}/{len(rad)}")
     ax.legend()
     plt.show()
 

--- a/examples/01_random_field/00_gaussian.py
+++ b/examples/01_random_field/00_gaussian.py
@@ -1,4 +1,4 @@
-"""
+r"""
 A Very Simple Example
 ---------------------
 

--- a/examples/01_random_field/05_mesh_ensemble.py
+++ b/examples/01_random_field/05_mesh_ensemble.py
@@ -46,13 +46,13 @@ srf = gs.SRF(model, mean=1)
 # You can specify the field name by the keyword `name`.
 
 for i in range(fields_no):
-    srf.mesh(mesh, points="centroids", name="c-field-{}".format(i), seed=i)
+    srf.mesh(mesh, points="centroids", name=f"c-field-{i}", seed=i)
 
 ###############################################################################
 # Now we generate fields on the mesh-points again controlled by a seed.
 
 for i in range(fields_no):
-    srf.mesh(mesh, points="points", name="p-field-{}".format(i), seed=i)
+    srf.mesh(mesh, points="points", name=f"p-field-{i}", seed=i)
 
 ###############################################################################
 # To get an impression we now want to plot the generated fields.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """GSTools: A geostatistical toolbox."""
 import os
 

--- a/src/gstools/__init__.py
+++ b/src/gstools/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Purpose
 =======

--- a/src/gstools/config.py
+++ b/src/gstools/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing global variables.
 

--- a/src/gstools/covmodel/__init__.py
+++ b/src/gstools/covmodel/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing a set of handy covariance models.
 

--- a/src/gstools/covmodel/base.py
+++ b/src/gstools/covmodel/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing the base class for covariance models.
 

--- a/src/gstools/covmodel/fit.py
+++ b/src/gstools/covmodel/fit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for the covariance-model.
 

--- a/src/gstools/covmodel/models.py
+++ b/src/gstools/covmodel/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing different covariance models.
 

--- a/src/gstools/covmodel/plot.py
+++ b/src/gstools/covmodel/plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing plotting routines for the covariance models.
 

--- a/src/gstools/covmodel/tools.py
+++ b/src/gstools/covmodel/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for the covariance-model.
 

--- a/src/gstools/covmodel/tpl_models.py
+++ b/src/gstools/covmodel/tpl_models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing truncated power law covariance models.
 

--- a/src/gstools/field/__init__.py
+++ b/src/gstools/field/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for spatial random fields.
 

--- a/src/gstools/field/base.py
+++ b/src/gstools/field/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing a base class for spatial fields.
 

--- a/src/gstools/field/cond_srf.py
+++ b/src/gstools/field/cond_srf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing a class for conditioned spatial random fields.
 

--- a/src/gstools/field/generator.py
+++ b/src/gstools/field/generator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing generators for spatial random fields.
 

--- a/src/gstools/field/plot.py
+++ b/src/gstools/field/plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing plotting routines for spatial fields.
 

--- a/src/gstools/field/srf.py
+++ b/src/gstools/field/srf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing a class for standard spatial random fields.
 

--- a/src/gstools/field/summator.pyx
+++ b/src/gstools/field/summator.pyx
@@ -1,5 +1,4 @@
 #cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
-# -*- coding: utf-8 -*-
 """
 This is the randomization method summator, implemented in cython.
 """

--- a/src/gstools/field/tools.py
+++ b/src/gstools/field/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for Fields.
 

--- a/src/gstools/field/upscaling.py
+++ b/src/gstools/field/upscaling.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing upscaling routines for the spatial random field.
 

--- a/src/gstools/krige/__init__.py
+++ b/src/gstools/krige/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing kriging.
 

--- a/src/gstools/krige/base.py
+++ b/src/gstools/krige/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing a base class for kriging.
 

--- a/src/gstools/krige/krigesum.pyx
+++ b/src/gstools/krige/krigesum.pyx
@@ -1,5 +1,4 @@
 #cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
-# -*- coding: utf-8 -*-
 """
 This is a summator for the kriging routines
 """

--- a/src/gstools/krige/methods.py
+++ b/src/gstools/krige/methods.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing a class for simple kriging.
 

--- a/src/gstools/krige/tools.py
+++ b/src/gstools/krige/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for Kriging.
 

--- a/src/gstools/normalizer/__init__.py
+++ b/src/gstools/normalizer/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing normalization routines.
 

--- a/src/gstools/normalizer/base.py
+++ b/src/gstools/normalizer/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing the base class for normalizers.
 

--- a/src/gstools/normalizer/methods.py
+++ b/src/gstools/normalizer/methods.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing different normalizer transformations.
 

--- a/src/gstools/normalizer/tools.py
+++ b/src/gstools/normalizer/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for Normalizers.
 

--- a/src/gstools/random/__init__.py
+++ b/src/gstools/random/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage for random number generation.
 

--- a/src/gstools/random/rng.py
+++ b/src/gstools/random/rng.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing the core of the spatial random field generation.
 

--- a/src/gstools/random/tools.py
+++ b/src/gstools/random/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for random sampling.
 

--- a/src/gstools/tools/__init__.py
+++ b/src/gstools/tools/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing miscellaneous tools.
 

--- a/src/gstools/tools/export.py
+++ b/src/gstools/tools/export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing export routines.
 

--- a/src/gstools/tools/geometric.py
+++ b/src/gstools/tools/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing geometric tools.
 

--- a/src/gstools/tools/misc.py
+++ b/src/gstools/tools/misc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing miscellaneous tools.
 

--- a/src/gstools/tools/special.py
+++ b/src/gstools/tools/special.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing special functions.
 

--- a/src/gstools/transform/__init__.py
+++ b/src/gstools/transform/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing transformations to post-process normal fields.
 

--- a/src/gstools/transform/array.py
+++ b/src/gstools/transform/array.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing array transformations.
 

--- a/src/gstools/transform/field.py
+++ b/src/gstools/transform/field.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing field transformations.
 

--- a/src/gstools/variogram/__init__.py
+++ b/src/gstools/variogram/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for estimating and fitting variograms.
 

--- a/src/gstools/variogram/binning.py
+++ b/src/gstools/variogram/binning.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing binning routines.
 

--- a/src/gstools/variogram/estimator.pyx
+++ b/src/gstools/variogram/estimator.pyx
@@ -1,6 +1,5 @@
 #cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 # distutils: language = c++
-# -*- coding: utf-8 -*-
 """
 This is the variogram estimater, implemented in cython.
 """
@@ -251,7 +250,7 @@ def unstructured(
     else:
         distance = dist_haversine
         if dim != 2:
-            raise ValueError('Haversine: dim = {0} != 2'.format(dim))
+            raise ValueError('Haversine: dim = {} != 2'.format(dim))
 
     if pos.shape[1] != f.shape[1]:
         raise ValueError('len(pos) = {0} != len(f) = {1} '.

--- a/src/gstools/variogram/estimator.pyx
+++ b/src/gstools/variogram/estimator.pyx
@@ -187,8 +187,7 @@ def directional(
     str estimator_type='m',
 ):
     if pos.shape[1] != f.shape[1]:
-        raise ValueError('len(pos) = {0} != len(f) = {1} '.
-                         format(pos.shape[1], f.shape[1]))
+        raise ValueError(f'len(pos) = {pos.shape[1]} != len(f) = {f.shape[1])}')
 
     if bin_edges.shape[0] < 2:
         raise ValueError('len(bin_edges) too small')
@@ -250,11 +249,10 @@ def unstructured(
     else:
         distance = dist_haversine
         if dim != 2:
-            raise ValueError('Haversine: dim = {} != 2'.format(dim))
+            raise ValueError(f'Haversine: dim = {dim} != 2')
 
     if pos.shape[1] != f.shape[1]:
-        raise ValueError('len(pos) = {0} != len(f) = {1} '.
-                         format(pos.shape[1], f.shape[1]))
+        raise ValueError(f'len(pos) = {pos.shape[1]} != len(f) = {f.shape[1])}')
 
     if bin_edges.shape[0] < 2:
         raise ValueError('len(bin_edges) too small')

--- a/src/gstools/variogram/variogram.py
+++ b/src/gstools/variogram/variogram.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 GStools subpackage providing tools for estimating and fitting variograms.
 

--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """This is the unittest of CondSRF class."""
 import unittest
 from copy import copy

--- a/tests/test_covmodel.py
+++ b/tests/test_covmodel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is the unittest of CovModel class.
 """

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 This is the unittest of SRF class.
 """

--- a/tests/test_incomprrandmeth.py
+++ b/tests/test_incomprrandmeth.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is the unittest of the RandMeth class.
 """

--- a/tests/test_krige.py
+++ b/tests/test_krige.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is the unittest of the kriging module.
 """

--- a/tests/test_latlon.py
+++ b/tests/test_latlon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is the unittest for latlon related routines.
 """

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is the unittest of the Normalizer class.
 """

--- a/tests/test_randmeth.py
+++ b/tests/test_randmeth.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is the unittest of the RandMeth class.
 """

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is the unittest of the RNG class.
 """

--- a/tests/test_srf.py
+++ b/tests/test_srf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 This is the unittest of SRF class.
 """

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """This is the unittest of the transform submodule."""
 import unittest
 

--- a/tests/test_variogram_structured.py
+++ b/tests/test_variogram_structured.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is a unittest of the variogram module.
 """

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is a unittest of the variogram module.
 """


### PR DESCRIPTION
These edits were automated using:

    pyupgrade --py37-plus `find . -name "*.py*"`

and does:

- Remove unnecessary `# -*- coding: utf-8 -*-` comment, since [PEP 3120](https://peps.python.org/pep-3120/) declared UTF-8 as the default source encoding since Python 3.0
- Convert a few f-strings
- Add missing `r` prefix for a raw string with `\` used for math markup