### PR TITLE
Python 3.12 support, Cython linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS: ${{ matrix.cfg.arch }}
         with:
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,20 +32,23 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black 'pylint<3' 'isort[colors]<6'
-          pip install -v --editable .
+          pip install -v --editable .[lint]
 
       - name: black check
         run: |
           python -m black --check --diff --color .
 
+      - name: isort check
+        run: |
+          python -m isort --check --diff --color .
+
       - name: pylint check
         run: |
           python -m pylint src/gstools/
 
-      - name: isort check
+      - name: cython-lint check
         run: |
-          python -m isort --check --diff --color .
+          cython-lint src/gstools/
 
   build_wheels:
     name: wheels for ${{ matrix.cfg.os }} / ${{ matrix.cfg.arch }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/source/conf.py
 
 formats: all
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to **GSTools** will be documented in this file.
 
+## [1.5.1] - Nifty Neon - 2023-11
+
+### Enhancements
+
+see [#317](https://github.com/GeoStat-Framework/GSTools/pull/317)
+
+- added wheels for Python 3.12
+- dropped support for Python 3.7 (EOL)
+- linted Cython files with cython-lint
+- use Cython 3 to build extensions
+
+
 ## [1.5.0] - Nifty Neon - 2023-06
 
 ### Enhancements
@@ -404,7 +416,8 @@ See: [#197](https://github.com/GeoStat-Framework/GSTools/issues/197)
 First release of GSTools.
 
 
-[Unreleased]: https://github.com/GeoStat-Framework/gstools/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/GeoStat-Framework/gstools/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/GeoStat-Framework/gstools/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/GeoStat-Framework/gstools/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/GeoStat-Framework/gstools/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/GeoStat-Framework/gstools/compare/v1.3.5...v1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ rust = ["gstools_core>=0.2.0,<1"]
 test = ["pytest-cov>=3"]
 lint = [
     "black",
-    "pylint<3",
-    "isort[colors]<6",
+    "pylint",
+    "isort[colors]",
     "cython-lint",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=64",
     "setuptools_scm>=7",
     "oldest-supported-numpy",
-    "Cython>=0.29.32,<3.0",
+    "Cython>=3.0",
     "extension-helpers>=1",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 name = "gstools"
 description = "GSTools: A geostatistical toolbox."
 authors = [
@@ -32,11 +32,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Scientific/Engineering :: Hydrology",
@@ -104,11 +104,11 @@ line_length = 79
 [tool.black]
 line-length = 79
 target-version = [
-    "py37",
     "py38",
     "py39",
     "py310",
     "py311",
+    "py312",
 ]
 
 [tool.coverage]
@@ -160,8 +160,8 @@ target-version = [
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
-# Disable building PyPy wheels on all platforms, 32bit for py3.10/11 and musllinux builds, py3.6
-skip = ["cp36-*", "pp*", "cp31*-win32", "cp31*-manylinux_i686", "*-musllinux_*"]
+# Disable building PyPy wheels on all platforms, 32bit for py3.10/11/12, musllinux builds, py3.6/7
+skip = ["cp36-*", "cp37-*", "pp*", "cp31*-win32", "cp31*-manylinux_i686", "*-musllinux_*"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ plotting = [
 ]
 rust = ["gstools_core>=0.2.0,<1"]
 test = ["pytest-cov>=3"]
+lint = [
+    "black",
+    "pylint<3",
+    "isort[colors]<6",
+    "cython-lint",
+]
 
 [project.urls]
 Changelog = "https://github.com/GeoStat-Framework/GSTools/blob/main/CHANGELOG.md"

--- a/src/gstools/field/summator.pyx
+++ b/src/gstools/field/summator.pyx
@@ -4,7 +4,6 @@ This is the randomization method summator, implemented in cython.
 """
 
 import numpy as np
-
 from cython.parallel import prange
 
 cimport numpy as np

--- a/src/gstools/field/summator.pyx
+++ b/src/gstools/field/summator.pyx
@@ -1,11 +1,9 @@
-#cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """
 This is the randomization method summator, implemented in cython.
 """
 
 import numpy as np
-
-cimport cython
 
 from cython.parallel import prange
 
@@ -18,7 +16,7 @@ def summate(
     const double[:] z_1,
     const double[:] z_2,
     const double[:, :] pos
-    ):
+):
     cdef int i, j, d
     cdef double phase
     cdef int dim = pos.shape[0]
@@ -53,7 +51,7 @@ def summate_incompr(
     const double[:] z_1,
     const double[:] z_2,
     const double[:, :] pos
-    ):
+):
     cdef int i, j, d
     cdef double phase
     cdef double k_2
@@ -76,6 +74,7 @@ def summate_incompr(
                 phase += cov_samples[d, j] * pos[d, i]
             for d in range(dim):
                 proj[d] = e1[d] - cov_samples[d, j] * cov_samples[0, j] / k_2
-                summed_modes[d, i] += proj[d] * (z_1[j] * cos(phase) + z_2[j] * sin(phase))
-
+                summed_modes[d, i] += (
+                    proj[d] * (z_1[j] * cos(phase) + z_2[j] * sin(phase))
+                )
     return np.asarray(summed_modes)

--- a/src/gstools/krige/krigesum.pyx
+++ b/src/gstools/krige/krigesum.pyx
@@ -1,11 +1,10 @@
-#cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """
 This is a summator for the kriging routines
 """
 
 import numpy as np
 
-cimport cython
 from cython.parallel import prange
 cimport numpy as np
 

--- a/src/gstools/krige/krigesum.pyx
+++ b/src/gstools/krige/krigesum.pyx
@@ -4,8 +4,8 @@ This is a summator for the kriging routines
 """
 
 import numpy as np
-
 from cython.parallel import prange
+
 cimport numpy as np
 
 

--- a/src/gstools/variogram/estimator.pyx
+++ b/src/gstools/variogram/estimator.pyx
@@ -5,7 +5,6 @@ This is the variogram estimater, implemented in cython.
 """
 
 import numpy as np
-
 from cython.parallel import parallel, prange
 
 cimport numpy as np


### PR DESCRIPTION
This PR adds fixes for complains from [cython-lint](https://github.com/MarcoGorelli/cython-lint) and adds a cython lint check in CI.

I also added the `lint` install flag for optional dependencies for linting (black, isort, pylint, cython-lint).

changes:
- added wheels for Python 3.12
- dropped support for Python 3.7 (EOL)
- linted Cython files with cython-lint
- use Cython 3 to build extensions
