### PR TITLE
tests: do setup and teardown only once per test-class

### DIFF
--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -8,7 +8,8 @@ import gstools as gs
 
 
 class TestCondition(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cov_models = [
             gs.Gaussian,
             gs.Exponential,

--- a/tests/test_covmodel.py
+++ b/tests/test_covmodel.py
@@ -67,7 +67,8 @@ class Mod_add(CovModel):
 
 
 class TestCovModel(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.std_cov_models = [
             Gaussian,
             Exponential,

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -20,7 +20,8 @@ except ImportError:
 
 
 class TestExport(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.test_dir = tempfile.mkdtemp()
         # structured field with a size 100x100x100 and a grid-size of 1x1x1
         x = y = z = range(50)
@@ -38,7 +39,8 @@ class TestExport(unittest.TestCase):
         self.srf_unstructured = SRF(model, seed=20170519)
         self.srf_unstructured([x, y])
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(self):
         # Remove the test data directory after the test
         shutil.rmtree(self.test_dir)
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -11,7 +11,8 @@ import gstools as gs
 
 
 class TestField(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4.0)
         rng = np.random.RandomState(123018)
         x = rng.uniform(0.0, 10, 100)

--- a/tests/test_incomprrandmeth.py
+++ b/tests/test_incomprrandmeth.py
@@ -12,7 +12,8 @@ from gstools.field.generator import IncomprRandMeth
 
 
 class TestIncomprRandMeth(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cov_model_2d = gs.Gaussian(dim=2, var=1.5, len_scale=2.5)
         self.cov_model_3d = copy.deepcopy(self.cov_model_2d)
         self.cov_model_3d.dim = 3

--- a/tests/test_krige.py
+++ b/tests/test_krige.py
@@ -18,7 +18,8 @@ def mean_func(*xyz):
 
 
 class TestKrige(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cov_models = [gs.Gaussian, gs.Exponential, gs.Spherical]
         self.dims = range(1, 4)
         self.data = np.array(

--- a/tests/test_latlon.py
+++ b/tests/test_latlon.py
@@ -22,7 +22,8 @@ class ErrMod(gs.CovModel):
 
 
 class TestLatLon(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cmod = gs.Gaussian(
             latlon=True, var=2, len_scale=777, geo_scale=gs.KM_SCALE
         )

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -14,7 +14,8 @@ def _rel_err(a, b):
 
 
 class TestNormalizer(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.seed = 20210111
         self.rng = gs.random.RNG(self.seed)
         self.mean = 11.1

--- a/tests/test_randmeth.py
+++ b/tests/test_randmeth.py
@@ -12,7 +12,8 @@ from gstools.field.generator import RandMeth
 
 
 class TestRandMeth(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cov_model_1d = Gaussian(dim=1, var=1.5, len_scale=3.5)
         self.cov_model_2d = copy.deepcopy(self.cov_model_1d)
         self.cov_model_2d.dim = 2
@@ -30,17 +31,17 @@ class TestRandMeth(unittest.TestCase):
         self.rm_2d = RandMeth(self.cov_model_2d, mode_no=100, seed=self.seed)
         self.rm_3d = RandMeth(self.cov_model_3d, mode_no=100, seed=self.seed)
 
-    def test_unstruct_1d(self):
+    def test_first_unstruct_1d(self):
         modes = self.rm_1d((self.x_tuple,))
         self.assertAlmostEqual(modes[0], 3.19799030)
         self.assertAlmostEqual(modes[1], 2.44848295)
 
-    def test_unstruct_2d(self):
+    def test_first_unstruct_2d(self):
         modes = self.rm_2d((self.x_tuple, self.y_tuple))
         self.assertAlmostEqual(modes[0], 1.67318010)
         self.assertAlmostEqual(modes[1], 2.12310269)
 
-    def test_unstruct_3d(self):
+    def test_first_unstruct_3d(self):
         modes = self.rm_3d((self.x_tuple, self.y_tuple, self.z_tuple))
         self.assertAlmostEqual(modes[0], 1.3240234883187239)
         self.assertAlmostEqual(modes[1], 1.6367244277732766)

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -12,7 +12,8 @@ from gstools.random.rng import RNG
 
 
 class TestRNG(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.seed = 19031977
         self.rng = RNG(self.seed)
         self.many_modes = 1000000

--- a/tests/test_srf.py
+++ b/tests/test_srf.py
@@ -21,7 +21,8 @@ except ImportError:
 
 
 class TestSRF(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4.0)
         self.mean = 0.3
         self.mode_no = 100

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -10,7 +10,8 @@ import gstools as gs
 
 
 class TestTemporal(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.mod = gs.Gaussian(
             latlon=True,
             temporal=True,

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -7,7 +7,8 @@ import gstools as gs
 
 
 class TestTransform(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4.0)
         self.mean = 0.3
         self.mode_no = 100

--- a/tests/test_variogram_structured.py
+++ b/tests/test_variogram_structured.py
@@ -10,7 +10,8 @@ import gstools as gs
 
 
 class TestVariogramStructured(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         pass
 
     def test_doubles(self):

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -10,7 +10,8 @@ import gstools as gs
 
 
 class TestVariogramUnstructured(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         model = gs.Exponential(dim=3, len_scale=[12, 6, 3])
         x = y = z = range(10)
         self.pos = (x, y, z)


### PR DESCRIPTION
This should speed-up the tests by only doing the setups/teardowns once per class.