### PR TITLE
Use integer literals where appropriate

### DIFF
--- a/examples/00_misc/05_standalone_field.py
+++ b/examples/00_misc/05_standalone_field.py
@@ -12,11 +12,11 @@ import numpy as np
 import gstools as gs
 
 rng = np.random.RandomState(19970221)
-x0 = rng.rand(10000) * 100.0
-x1 = rng.rand(10000) * 100.0
-x2 = rng.rand(10000) * 100.0
-x3 = rng.rand(10000) * 100.0
-values = rng.rand(10000) * 100.0
+x0 = rng.rand(10000) * 100
+x1 = rng.rand(10000) * 100
+x2 = rng.rand(10000) * 100
+x3 = rng.rand(10000) * 100
+values = rng.rand(10000) * 100
 
 ###############################################################################
 # Only thing needed to instantiate the Field is the dimension.

--- a/examples/03_variogram/00_fit_variogram.py
+++ b/examples/03_variogram/00_fit_variogram.py
@@ -9,8 +9,8 @@ import gstools as gs
 ###############################################################################
 # Generate a synthetic field with an exponential model.
 
-x = np.random.RandomState(19970221).rand(1000) * 100.0
-y = np.random.RandomState(20011012).rand(1000) * 100.0
+x = np.random.RandomState(19970221).rand(1000) * 100
+y = np.random.RandomState(20011012).rand(1000) * 100
 model = gs.Exponential(dim=2, var=2, len_scale=8)
 srf = gs.SRF(model, mean=0, seed=19970221)
 field = srf((x, y))

--- a/examples/03_variogram/01_find_best_model.py
+++ b/examples/03_variogram/01_find_best_model.py
@@ -10,8 +10,8 @@ import gstools as gs
 ###############################################################################
 # Generate a synthetic field with an exponential model.
 
-x = np.random.RandomState(19970221).rand(1000) * 100.0
-y = np.random.RandomState(20011012).rand(1000) * 100.0
+x = np.random.RandomState(19970221).rand(1000) * 100
+y = np.random.RandomState(20011012).rand(1000) * 100
 model = gs.Exponential(dim=2, var=2, len_scale=8)
 srf = gs.SRF(model, mean=0, seed=19970221)
 field = srf((x, y))

--- a/examples/03_variogram/02_multi_vario.py
+++ b/examples/03_variogram/02_multi_vario.py
@@ -10,8 +10,8 @@ import numpy as np
 
 import gstools as gs
 
-x = np.random.RandomState(19970221).rand(1000) * 100.0
-y = np.random.RandomState(20011012).rand(1000) * 100.0
+x = np.random.RandomState(19970221).rand(1000) * 100
+y = np.random.RandomState(20011012).rand(1000) * 100
 model = gs.Exponential(dim=2, var=2, len_scale=8)
 srf = gs.SRF(model, mean=0)
 

--- a/examples/03_variogram/05_auto_fit_variogram.py
+++ b/examples/03_variogram/05_auto_fit_variogram.py
@@ -9,8 +9,8 @@ import gstools as gs
 ###############################################################################
 # Generate a synthetic field with an exponential model.
 
-x = np.random.RandomState(19970221).rand(1000) * 100.0
-y = np.random.RandomState(20011012).rand(1000) * 100.0
+x = np.random.RandomState(19970221).rand(1000) * 100
+y = np.random.RandomState(20011012).rand(1000) * 100
 model = gs.Exponential(dim=2, var=2, len_scale=8)
 srf = gs.SRF(model, mean=0, seed=19970221)
 field = srf((x, y))

--- a/examples/09_spatio_temporal/01_precip_1d.py
+++ b/examples/09_spatio_temporal/01_precip_1d.py
@@ -67,14 +67,14 @@ P_cut[P_cut <= threshold] = 0.0
 # the lower this value, the more will be cut off, a value of 0.2 cuts off
 # nearly everything in this example.
 cutoff = 0.55
-gs.transform.boxcox(srf, lmbda=0.5, shift=-1.0 / cutoff)
+gs.transform.boxcox(srf, lmbda=0.5, shift=-1 / cutoff)
 
 ###############################################################################
 # As a last step, the amount of precipitation is set. This should of course be
 # calibrated towards observations (the same goes for the threshold, the
 # variance, correlation length, and so on).
 
-amount = 2.0
+amount = 2
 srf.field *= amount
 P_ana = srf.field
 

--- a/examples/09_spatio_temporal/02_precip_2d.py
+++ b/examples/09_spatio_temporal/02_precip_2d.py
@@ -44,7 +44,7 @@ srf.structured(pos + time)
 
 # account for the skewness and the dry periods
 cutoff = 0.55
-gs.transform.boxcox(srf, lmbda=0.5, shift=-1.0 / cutoff)
+gs.transform.boxcox(srf, lmbda=0.5, shift=-1 / cutoff)
 
 # adjust the amount of precipitation
 amount = 4.0

--- a/examples/10_normalizer/00_lognormal_kriging.py
+++ b/examples/10_normalizer/00_lognormal_kriging.py
@@ -22,7 +22,7 @@ import gstools as gs
 cond_pos = [0.3, 1.9, 1.1, 3.3, 4.7]
 cond_val = [0.47, 0.56, 0.74, 1.47, 1.74]
 # resulting grid
-gridx = np.linspace(0.0, 15.0, 151)
+gridx = np.linspace(0, 15, 151)
 # stable covariance model
 model = gs.Stable(dim=1, var=0.5, len_scale=2.56, alpha=1.9)
 

--- a/src/gstools/covmodel/base.py
+++ b/src/gstools/covmodel/base.py
@@ -1184,12 +1184,12 @@ class CovModel:
     @property
     def do_rotation(self):
         """:any:`bool`: State if a rotation is performed."""
-        return not np.all(np.isclose(self.angles, 0.0))
+        return not np.all(np.isclose(self.angles, 0))
 
     @property
     def is_isotropic(self):
         """:any:`bool`: State if a model is isotropic."""
-        return np.all(np.isclose(self.anis, 1.0))
+        return np.all(np.isclose(self.anis, 1))
 
     def __eq__(self, other):
         """Compare CovModels."""

--- a/src/gstools/covmodel/fit.py
+++ b/src/gstools/covmodel/fit.py
@@ -348,13 +348,13 @@ def _check_vario(model, x_data, y_data):
 def _set_weights(model, weights, x_data, curve_fit_kwargs, is_dir_vario):
     if weights is not None:
         if callable(weights):
-            weights = 1.0 / weights(x_data)
+            weights = 1 / weights(x_data)
         elif isinstance(weights, str) and weights == "inv":
-            weights = 1.0 + x_data
+            weights = 1 + x_data
         else:
             if is_dir_vario and weights.size * model.dim == x_data.size:
                 weights = np.tile(weights, model.dim)
-            weights = 1.0 / np.asarray(weights).reshape(-1)
+            weights = 1 / np.asarray(weights).reshape(-1)
         curve_fit_kwargs["sigma"] = weights
         curve_fit_kwargs["absolute_sigma"] = True
 
@@ -500,7 +500,7 @@ def _r2_score(model, x_data, y_data, is_dir_vario):
     residuals = y_data - vario
     ss_res = np.sum(residuals**2)
     ss_tot = np.sum((y_data - np.mean(y_data)) ** 2)
-    return 1.0 - (ss_res / ss_tot)
+    return 1 - (ss_res / ss_tot)
 
 
 def logistic_weights(p=0.1, mean=0.7):  # pragma: no cover
@@ -530,6 +530,6 @@ def logistic_weights(p=0.1, mean=0.7):  # pragma: no cover
         # logit function for growth rate
         growth = np.log(p / (1 - p)) / (p * x_range)
         x_mean = mean * x_range + np.amin(x_data)
-        return 1.0 / (1.0 + np.exp(growth * (x_mean - x_data)))
+        return 1 / (1 + np.exp(growth * (x_mean - x_data)))
 
     return func

--- a/src/gstools/covmodel/models.py
+++ b/src/gstools/covmodel/models.py
@@ -74,26 +74,26 @@ class Gaussian(CovModel):
 
     def default_rescale(self):
         """Gaussian rescaling factor to result in integral scale."""
-        return np.sqrt(np.pi) / 2.0
+        return np.sqrt(np.pi) / 2
 
     def spectral_density(self, k):  # noqa: D102
         k = np.asarray(k, dtype=np.double)
-        return (self.len_rescaled / 2.0 / np.sqrt(np.pi)) ** self.dim * np.exp(
-            -((k * self.len_rescaled / 2.0) ** 2)
+        return (self.len_rescaled / 2 / np.sqrt(np.pi)) ** self.dim * np.exp(
+            -((k * self.len_rescaled / 2) ** 2)
         )
 
     def spectral_rad_cdf(self, r):
         """Gaussian radial spectral cdf."""
         r = np.asarray(r, dtype=np.double)
         if self.dim == 1:
-            return sps.erf(r * self.len_rescaled / 2.0)
+            return sps.erf(r * self.len_rescaled / 2)
         if self.dim == 2:
-            return 1.0 - np.exp(-((r * self.len_rescaled / 2.0) ** 2))
+            return 1 - np.exp(-((r * self.len_rescaled / 2) ** 2))
         if self.dim == 3:
             return sps.erf(
-                r * self.len_rescaled / 2.0
+                r * self.len_rescaled / 2
             ) - r * self.len_rescaled / np.sqrt(np.pi) * np.exp(
-                -((r * self.len_rescaled / 2.0) ** 2)
+                -((r * self.len_rescaled / 2) ** 2)
             )
         return None  # pragma: no cover
 
@@ -106,9 +106,9 @@ class Gaussian(CovModel):
         """
         u = np.asarray(u, dtype=np.double)
         if self.dim == 1:
-            return 2.0 / self.len_rescaled * sps.erfinv(u)
+            return 2 / self.len_rescaled * sps.erfinv(u)
         if self.dim == 2:
-            return 2.0 / self.len_rescaled * np.sqrt(-np.log(1.0 - u))
+            return 2 / self.len_rescaled * np.sqrt(-np.log(1 - u))
         return None  # pragma: no cover
 
     def _has_cdf(self):
@@ -118,7 +118,7 @@ class Gaussian(CovModel):
         return self.dim in [1, 2]
 
     def calc_integral_scale(self):  # noqa: D102
-        return self.len_rescaled * np.sqrt(np.pi) / 2.0
+        return self.len_rescaled * np.sqrt(np.pi) / 2
 
 
 class Exponential(CovModel):
@@ -150,27 +150,27 @@ class Exponential(CovModel):
         k = np.asarray(k, dtype=np.double)
         return (
             self.len_rescaled**self.dim
-            * sps.gamma((self.dim + 1) / 2.0)
-            / (np.pi * (1.0 + (k * self.len_rescaled) ** 2))
-            ** ((self.dim + 1) / 2.0)
+            * sps.gamma((self.dim + 1) / 2)
+            / (np.pi * (1 + (k * self.len_rescaled) ** 2))
+            ** ((self.dim + 1) / 2)
         )
 
     def spectral_rad_cdf(self, r):
         """Exponential radial spectral cdf."""
         r = np.asarray(r, dtype=np.double)
         if self.dim == 1:
-            return np.arctan(r * self.len_rescaled) * 2.0 / np.pi
+            return np.arctan(r * self.len_rescaled) * 2 / np.pi
         if self.dim == 2:
-            return 1.0 - 1.0 / np.sqrt(1.0 + (r * self.len_rescaled) ** 2)
+            return 1 - 1 / np.sqrt(1 + (r * self.len_rescaled) ** 2)
         if self.dim == 3:
             return (
                 (
                     np.arctan(r * self.len_rescaled)
                     - r
                     * self.len_rescaled
-                    / (1.0 + (r * self.len_rescaled) ** 2)
+                    / (1 + (r * self.len_rescaled) ** 2)
                 )
-                * 2.0
+                * 2
                 / np.pi
             )
         return None  # pragma: no cover
@@ -192,7 +192,7 @@ class Exponential(CovModel):
                 out=np.full_like(u, np.inf),
                 where=np.logical_not(np.isclose(u, 0)),
             )
-            return np.sqrt(u_power - 1.0) / self.len_rescaled
+            return np.sqrt(u_power - 1) / self.len_rescaled
         return None  # pragma: no cover
 
     def _has_cdf(self):
@@ -277,7 +277,7 @@ class Stable(CovModel):
         return np.exp(-np.power(h, self.alpha))
 
     def calc_integral_scale(self):  # noqa: D102
-        return self.len_rescaled * sps.gamma(1.0 + 1.0 / self.alpha)
+        return self.len_rescaled * sps.gamma(1 + 1 / self.alpha)
 
 
 class Matern(CovModel):
@@ -347,27 +347,27 @@ class Matern(CovModel):
         """Matérn normalized correlation function."""
         h = np.asarray(np.abs(h), dtype=np.double)
         # for nu > 20 we just use the gaussian model
-        if self.nu > 20.0:
-            return np.exp(-((h / 2.0) ** 2))
+        if self.nu > 20:
+            return np.exp(-((h / 2) ** 2))
         # calculate by log-transformation to prevent numerical errors
-        h_gz = h[h > 0.0]
+        h_gz = h[h > 0]
         res = np.ones_like(h)
-        res[h > 0.0] = np.exp(
-            (1.0 - self.nu) * np.log(2)
+        res[h > 0] = np.exp(
+            (1 - self.nu) * np.log(2)
             - sps.loggamma(self.nu)
             + self.nu * np.log(np.sqrt(self.nu) * h_gz)
         ) * sps.kv(self.nu, np.sqrt(self.nu) * h_gz)
         # if nu >> 1 we get errors for the farfield, there 0 is approached
-        res[np.logical_not(np.isfinite(res))] = 0.0
+        res[np.logical_not(np.isfinite(res))] = 0
         # covariance is positive
-        res = np.maximum(res, 0.0)
+        res = np.maximum(res, 0)
         return res
 
     def spectral_density(self, k):  # noqa: D102
         k = np.asarray(k, dtype=np.double)
         x = (k * self.len_rescaled) ** 2
         # for nu > 20 we just use an approximation of the gaussian model
-        if self.nu > 20.0:
+        if self.nu > 20:
             return (
                 (self.len_rescaled / np.sqrt(np.pi)) ** self.dim
                 * np.exp(-x)
@@ -375,8 +375,8 @@ class Matern(CovModel):
                 * np.sqrt(1 + x / self.nu) ** (-self.dim)
             )
         return (self.len_rescaled / np.sqrt(np.pi)) ** self.dim * np.exp(
-            -(self.nu + self.dim / 2.0) * np.log(1.0 + x / self.nu)
-            + sps.loggamma(self.nu + self.dim / 2.0)
+            -(self.nu + self.dim / 2) * np.log(1 + x / self.nu)
+            + sps.loggamma(self.nu + self.dim / 2)
             - sps.loggamma(self.nu)
             - self.dim * np.log(np.sqrt(self.nu))
         )
@@ -455,29 +455,29 @@ class Integral(CovModel):
     def cor(self, h):
         """Exponential Integral normalized correlation function."""
         h = np.asarray(h, dtype=np.double)
-        return 0.5 * self.nu * exp_int(1.0 + 0.5 * self.nu, h**2)
+        return 0.5 * self.nu * exp_int(1 + 0.5 * self.nu, h**2)
 
     def spectral_density(self, k):  # noqa: D102
         k = np.asarray(k, dtype=np.double)
-        x = (k * self.len_rescaled / 2.0) ** 2
+        x = (k * self.len_rescaled / 2) ** 2
         # for nu > 50 we just use an approximation of the gaussian model
-        if self.nu > 50.0:
+        if self.nu > 50:
             return (
                 (0.5 * self.len_rescaled / np.sqrt(np.pi)) ** self.dim
                 * np.exp(-x)
                 * self.nu
                 / (self.nu + self.dim)
-                * (1.0 + 2 * x / (self.nu + self.dim + 2))
+                * (1 + 2 * x / (self.nu + self.dim + 2))
             )
         return (
             self.nu
             / (x ** (self.nu * 0.5) * 2 * (k * np.sqrt(np.pi)) ** self.dim)
-            * inc_gamma_low((self.nu + self.dim) / 2.0, x)
+            * inc_gamma_low((self.nu + self.dim) / 2, x)
         )
 
     def calc_integral_scale(self):  # noqa: D102
         return (
-            self.len_rescaled * self.nu * np.sqrt(np.pi) / (2 * self.nu + 2.0)
+            self.len_rescaled * self.nu * np.sqrt(np.pi) / (2 * self.nu + 2)
         )
 
 
@@ -549,7 +549,7 @@ class Rational(CovModel):
             * np.sqrt(np.pi * self.alpha)
             * sps.gamma(self.alpha - 0.5)
             / sps.gamma(self.alpha)
-            / 2.0
+            / 2
         )
 
 
@@ -585,8 +585,8 @@ class Cubic(CovModel):
 
     def cor(self, h):
         """Spherical normalized correlation function."""
-        h = np.minimum(np.abs(h, dtype=np.double), 1.0)
-        return 1.0 - 7 * h**2 + 8.75 * h**3 - 3.5 * h**5 + 0.75 * h**7
+        h = np.minimum(np.abs(h, dtype=np.double), 1)
+        return 1 - 7 * h**2 + 8.75 * h**3 - 3.5 * h**5 + 0.75 * h**7
 
 
 class Linear(CovModel):
@@ -662,7 +662,7 @@ class Circular(CovModel):
         h = np.asarray(np.abs(h), dtype=np.double)
         res = np.zeros_like(h)
         # arccos is instable around h=1
-        h_l1 = h < 1.0
+        h_l1 = h < 1
         h_low = h[h_l1]
         res[h_l1] = (
             2 / np.pi * (np.arccos(h_low) - h_low * np.sqrt(1 - h_low**2))
@@ -705,8 +705,8 @@ class Spherical(CovModel):
 
     def cor(self, h):
         """Spherical normalized correlation function."""
-        h = np.minimum(np.abs(h, dtype=np.double), 1.0)
-        return 1.0 - 1.5 * h + 0.5 * h**3
+        h = np.minimum(np.abs(h, dtype=np.double), 1)
+        return 1 - 1.5 * h + 0.5 * h**3
 
     def check_dim(self, dim):
         """Spherical model is only valid in 1D, 2D and 3D."""
@@ -753,8 +753,8 @@ class HyperSpherical(CovModel):
         h = np.asarray(h, dtype=np.double)
         res = np.zeros_like(h)
         h_l1 = h < 1
-        nu = (self.dim - 1.0) / 2.0
-        fac = 1.0 / sps.hyp2f1(0.5, -nu, 1.5, 1)
+        nu = (self.dim - 1) / 2
+        fac = 1 / sps.hyp2f1(0.5, -nu, 1.5, 1)
         res[h_l1] = 1 - h[h_l1] * fac * sps.hyp2f1(0.5, -nu, 1.5, h[h_l1] ** 2)
         return res
 
@@ -836,15 +836,15 @@ class SuperSpherical(CovModel):
         :class:`dict`
             Boundaries for optional arguments
         """
-        return {"nu": [(self.dim - 1) / 2, 50.0]}
+        return {"nu": [(self.dim - 1) / 2, 50]}
 
     def cor(self, h):
         """Super-Spherical normalized correlation function."""
         h = np.asarray(h, dtype=np.double)
         res = np.zeros_like(h)
         h_l1 = h < 1
-        fac = 1.0 / sps.hyp2f1(0.5, -self.nu, 1.5, 1.0)
-        res[h_l1] = 1.0 - h[h_l1] * fac * sps.hyp2f1(
+        fac = 1 / sps.hyp2f1(0.5, -self.nu, 1.5, 1)
+        res[h_l1] = 1 - h[h_l1] * fac * sps.hyp2f1(
             0.5, -self.nu, 1.5, h[h_l1] ** 2
         )
         return res
@@ -916,7 +916,7 @@ class JBessel(CovModel):
         :class:`dict`
             Boundaries for optional arguments
         """
-        return {"nu": [self.dim / 2 - 1, 50.0]}
+        return {"nu": [self.dim / 2 - 1, 50]}
 
     def check_opt_arg(self):
         """Check the optional arguments.
@@ -940,20 +940,20 @@ class JBessel(CovModel):
         hh = h[h_gz]
         res = np.ones_like(h)
         nu = self.nu
-        res[h_gz] = sps.gamma(nu + 1) * sps.jv(nu, hh) / (hh / 2.0) ** nu
+        res[h_gz] = sps.gamma(nu + 1) * sps.jv(nu, hh) / (hh / 2) ** nu
         return res
 
     def spectral_density(self, k):  # noqa: D102
         k = np.asarray(k, dtype=np.double)
-        k_ll = k < 1.0 / self.len_rescaled
+        k_ll = k < 1 / self.len_rescaled
         kk = k[k_ll]
         res = np.zeros_like(k)
         # the model is degenerated for nu=d/2-1, so we tweak the spectral pdf
         # and cut of the divisor at nu-(d/2-1)=0.01 (gamma(0.01) about 100)
         res[k_ll] = (
             (self.len_rescaled / np.sqrt(np.pi)) ** self.dim
-            * sps.gamma(self.nu + 1.0)
-            / np.minimum(sps.gamma(self.nu - self.dim / 2 + 1), 100.0)
-            * (1.0 - (kk * self.len_rescaled) ** 2) ** (self.nu - self.dim / 2)
+            * sps.gamma(self.nu + 1)
+            / np.minimum(sps.gamma(self.nu - self.dim / 2 + 1), 100)
+            * (1 - (kk * self.len_rescaled) ** 2) ** (self.nu - self.dim / 2)
         )
         return res

--- a/src/gstools/covmodel/tools.py
+++ b/src/gstools/covmodel/tools.py
@@ -69,7 +69,7 @@ def _init_subclass(cls):
 
     def correlation(self, r):
         """Correlation function of the model."""
-        return 1.0 - (self.variogram(r) - self.nugget) / self.var
+        return 1 - (self.variogram(r) - self.nugget) / self.var
 
     def correlation_from_cor(self, r):
         """Correlation function of the model."""
@@ -124,7 +124,7 @@ def rad_fac(dim, r):
         Given radii.
     """
     if dim == 1:
-        fac = 2.0
+        fac = 2
     elif dim == 2:
         fac = 2 * np.pi * r
     elif dim == 3:
@@ -236,13 +236,13 @@ def set_len_anis(dim, len_scale, anis, latlon=False):
             out_anis[i - 1] = ls_tmp[i] / ls_tmp[0]
     # sanity check
     for ani in out_anis:
-        if not ani > 0.0:
+        if not ani > 0:
             raise ValueError(
                 f"anisotropy-ratios needs to be > 0, got: {out_anis}"
             )
     # no spatial anisotropy for latlon
     if latlon:
-        out_anis[:2] = 1.0
+        out_anis[:2] = 1
     return out_len_scale, out_anis
 
 
@@ -277,7 +277,7 @@ def set_model_angles(dim, angles, latlon=False, temporal=False):
     out_angles = set_angles(dim, angles)
     if temporal:
         # no rotation between spatial dimensions and temporal dimension
-        out_angles[no_of_angles(dim - 1) :] = 0.0
+        out_angles[no_of_angles(dim - 1) :] = 0
     return out_angles
 
 
@@ -348,12 +348,12 @@ def default_arg_from_bounds(bounds):
         Default value in the given bounds.
     """
     if bounds[0] > -np.inf and bounds[1] < np.inf:
-        return (bounds[0] + bounds[1]) / 2.0
+        return (bounds[0] + bounds[1]) / 2
     if bounds[0] > -np.inf:
-        return bounds[0] + 1.0
+        return bounds[0] + 1
     if bounds[1] < np.inf:
-        return bounds[1] - 1.0
-    return 0.0  # pragma: no cover
+        return bounds[1] - 1
+    return 0  # pragma: no cover
 
 
 # outsourced routines
@@ -387,9 +387,9 @@ def spectral_rad_pdf(model, r):
     else:
         res = rad_fac(model.dim, r) * np.abs(model.spectral_density(r))
     # prevent numerical errors in hankel for small r values (set 0)
-    res[np.logical_not(np.isfinite(res))] = 0.0
+    res[np.logical_not(np.isfinite(res))] = 0
     # prevent numerical errors in hankel for big r (set non-negative)
-    res = np.maximum(res, 0.0)
+    res = np.maximum(res, 0)
     return res
 
 
@@ -420,12 +420,12 @@ def percentile_scale(model, per=0.9):
 
     """
     # check the given percentile
-    if not 0.0 < per < 1.0:
+    if not 0 < per < 1:
         raise ValueError(f"percentile needs to be within (0, 1), got: {per}")
 
     # define a curve, that has its root at the wanted point
     def curve(x):
-        return 1.0 - model.correlation(x) - per
+        return 1 - model.correlation(x) - per
 
     # take 'per * len_rescaled' as initial guess
     return root(curve, per * model.len_rescaled)["x"][0]

--- a/src/gstools/covmodel/tpl_models.py
+++ b/src/gstools/covmodel/tpl_models.py
@@ -167,7 +167,7 @@ class TPLGaussian(TPLCovModel):
         :class:`dict`
             Defaults for optional arguments
         """
-        return {"hurst": 0.5, "len_low": 0.0}
+        return {"hurst": 0.5, "len_low": 0}
 
     def default_opt_arg_bounds(self):
         """Defaults for boundaries of the optional arguments.
@@ -179,16 +179,16 @@ class TPLGaussian(TPLCovModel):
         :class:`dict`
             Boundaries for optional arguments
         """
-        return {"hurst": (0.1, 1, "oo"), "len_low": (0.0, np.inf, "co")}
+        return {"hurst": (0.1, 1, "oo"), "len_low": (0, np.inf, "co")}
 
     def cor(self, h):
         """TPL with Gaussian modes - normalized correlation function."""
-        return tplstable_cor(h, 1.0, self.hurst, 2)
+        return tplstable_cor(h, 1, self.hurst, 2)
 
     def correlation(self, r):
         """TPL with Gaussian modes - correlation function."""
         # if lower limit is 0 we use the simplified version (faster)
-        if np.isclose(self.len_low_rescaled, 0.0):
+        if np.isclose(self.len_low_rescaled, 0):
             return tplstable_cor(r, self.len_rescaled, self.hurst, 2)
         return (
             self.len_up_rescaled ** (2 * self.hurst)
@@ -438,7 +438,7 @@ class TPLStable(TPLCovModel):
         :class:`dict`
             Defaults for optional arguments
         """
-        return {"hurst": 0.5, "alpha": 1.5, "len_low": 0.0}
+        return {"hurst": 0.5, "alpha": 1.5, "len_low": 0}
 
     def default_opt_arg_bounds(self):
         """Defaults for boundaries of the optional arguments.
@@ -476,12 +476,12 @@ class TPLStable(TPLCovModel):
 
     def cor(self, h):
         """TPL with Stable modes - normalized correlation function."""
-        return tplstable_cor(h, 1.0, self.hurst, self.alpha)
+        return tplstable_cor(h, 1, self.hurst, self.alpha)
 
     def correlation(self, r):
         """TPL with Stable modes - correlation function."""
         # if lower limit is 0 we use the simplified version (faster)
-        if np.isclose(self.len_low_rescaled, 0.0):
+        if np.isclose(self.len_low_rescaled, 0):
             return tplstable_cor(r, self.len_rescaled, self.hurst, self.alpha)
         return (
             self.len_up_rescaled ** (2 * self.hurst)
@@ -562,8 +562,8 @@ class TPLSimple(CovModel):
         :class:`dict`
             Boundaries for optional arguments
         """
-        return {"nu": [(self.dim + 1) / 2, 50.0]}
+        return {"nu": [(self.dim + 1) / 2, 50]}
 
     def cor(self, h):
         """TPL Simple - normalized correlation function."""
-        return np.maximum(1 - np.abs(h, dtype=np.double), 0.0) ** self.nu
+        return np.maximum(1 - np.abs(h, dtype=np.double), 0) ** self.nu

--- a/src/gstools/field/generator.py
+++ b/src/gstools/field/generator.py
@@ -210,7 +210,7 @@ class RandMeth(Generator):
         """
         pos = np.asarray(pos, dtype=np.double)
         summed_modes = summate(self._cov_sample, self._z_1, self._z_2, pos)
-        nugget = self.get_nugget(summed_modes.shape) if add_nugget else 0.0
+        nugget = self.get_nugget(summed_modes.shape) if add_nugget else 0
         return np.sqrt(self.model.var / self._mode_no) * summed_modes + nugget
 
     def get_nugget(self, shape):
@@ -232,7 +232,7 @@ class RandMeth(Generator):
                 size=shape
             )
         else:
-            nugget = 0.0
+            nugget = 0
         return nugget
 
     def update(self, model=None, seed=np.nan):
@@ -322,7 +322,7 @@ class RandMeth(Generator):
             rad = self._rng.sample_ln_pdf(
                 ln_pdf=self.model.ln_spectral_rad_pdf,
                 size=self._mode_no,
-                sample_around=1.0 / self.model.len_rescaled,
+                sample_around=1 / self.model.len_rescaled,
             )
         # get fully spatial samples by multiplying sphere samples and radii
         self._cov_sample = rad * sphere_coord
@@ -446,7 +446,7 @@ class IncomprRandMeth(RandMeth):
         self,
         model,
         *,
-        mean_velocity=1.0,
+        mean_velocity=1,
         mode_no=1000,
         seed=None,
         sampling="auto",
@@ -491,7 +491,7 @@ class IncomprRandMeth(RandMeth):
         summed_modes = summate_incompr(
             self._cov_sample, self._z_1, self._z_2, pos
         )
-        nugget = self.get_nugget(summed_modes.shape) if add_nugget else 0.0
+        nugget = self.get_nugget(summed_modes.shape) if add_nugget else 0
         e1 = self._create_unit_vector(summed_modes.shape)
         return (
             self.mean_u * e1
@@ -523,5 +523,5 @@ class IncomprRandMeth(RandMeth):
         shape[0] = self.model.dim
 
         e1 = np.zeros(shape)
-        e1[axis] = 1.0
+        e1[axis] = 1
         return e1

--- a/src/gstools/field/plot.py
+++ b/src/gstools/field/plot.py
@@ -283,7 +283,7 @@ def plot_nd(
         for i, s in zip(cut_select, slider):
             s.label.set_text(ax_names[i])
             s.valmin, s.valmax = ax_ends[i]
-            s.valinit = ax_ends[i][0] + ax_rngs[i] / 2.0
+            s.valinit = ax_ends[i][0] + ax_rngs[i] / 2
             s.valstep = ax_steps[i]
             s.ax.set_xlim(*ax_ends[i])
             # update representation

--- a/src/gstools/field/srf.py
+++ b/src/gstools/field/srf.py
@@ -84,7 +84,7 @@ class SRF(Field):
     def __init__(
         self,
         model,
-        mean=0.0,
+        mean=0,
         normalizer=None,
         trend=None,
         upscaling="no_scaling",
@@ -104,7 +104,7 @@ class SRF(Field):
         self,
         pos=None,
         seed=np.nan,
-        point_volumes=0.0,
+        point_volumes=0,
         mesh_type="unstructured",
         post_process=True,
         store=True,

--- a/src/gstools/field/upscaling.py
+++ b/src/gstools/field/upscaling.py
@@ -73,10 +73,10 @@ def var_coarse_graining(model, point_volumes=0.0):
             "var_coarse_graining: non-zero nugget will violate upscaling!"
         )
     # interpret volume as a hypercube and calculate the edge length
-    edge = point_volumes ** (1.0 / model.dim)
+    edge = point_volumes ** (1 / model.dim)
     var_factor = (
         model.len_scale**2 / (model.len_scale**2 + edge**2 / 4)
-    ) ** (model.dim / 2.0)
+    ) ** (model.dim / 2)
 
     return model.sill * var_factor
 

--- a/src/gstools/krige/base.py
+++ b/src/gstools/krige/base.py
@@ -449,13 +449,13 @@ class Krige(Field):
         # if mean should not be post-processed, it exists when no drift given
         if not self.has_const_mean and (post_process or self.drift_no > 0):
             return None
-        res = 0.0  # for simple kriging return the given mean
+        res = 0  # for simple kriging return the given mean
         # correctly setting given mean
-        mean = 0.0 if self.mean is None else self.mean
+        mean = 0 if self.mean is None else self.mean
         # for ordinary kriging return the estimated mean
         if self.unbiased:
             # set the right side of the kriging system to the limit of cov.
-            mean_est = np.concatenate((np.full_like(self.cond_val, 0.0), [1]))
+            mean_est = np.concatenate((np.full_like(self.cond_val, 0), [1]))
             # execute the kriging routine with einsum
             res = np.einsum(
                 "i,ij,j", self._krige_cond, self._krige_mat, mean_est

--- a/src/gstools/krige/methods.py
+++ b/src/gstools/krige/methods.py
@@ -92,7 +92,7 @@ class Simple(Krige):
         model,
         cond_pos,
         cond_val,
-        mean=0.0,
+        mean=0,
         normalizer=None,
         trend=None,
         exact=False,

--- a/src/gstools/krige/tools.py
+++ b/src/gstools/krige/tools.py
@@ -87,7 +87,7 @@ def get_drift_functions(dim, drift_type):
 
 def _f_factory(select):
     def f(*pos):
-        res = 1.0
+        res = 1
         for i in select:
             res *= np.asarray(pos[i])
         return res

--- a/src/gstools/random/rng.py
+++ b/src/gstools/random/rng.py
@@ -39,7 +39,7 @@ class RNG:
         self,
         ln_pdf,
         size=None,
-        sample_around=1.0,
+        sample_around=1,
         nwalkers=50,
         burn_in=20,
         oversampling_factor=10,
@@ -163,14 +163,14 @@ class RNG:
         if dim == 1:
             coord[0] = self.random.choice([-1, 1], size=size)
         elif dim == 2:
-            ang1 = self.random.uniform(0.0, 2 * np.pi, size)
+            ang1 = self.random.uniform(0, 2 * np.pi, size)
             coord[0] = np.cos(ang1)
             coord[1] = np.sin(ang1)
         elif dim == 3:
-            ang1 = self.random.uniform(0.0, 2 * np.pi, size)
-            ang2 = self.random.uniform(-1.0, 1.0, size)
-            coord[0] = np.sqrt(1.0 - ang2**2) * np.cos(ang1)
-            coord[1] = np.sqrt(1.0 - ang2**2) * np.sin(ang1)
+            ang1 = self.random.uniform(0, 2 * np.pi, size)
+            ang2 = self.random.uniform(-1, 1, size)
+            coord[0] = np.sqrt(1 - ang2**2) * np.cos(ang1)
+            coord[1] = np.sqrt(1 - ang2**2) * np.sin(ang1)
             coord[2] = ang2
         else:  # pragma: no cover
             # http://corysimon.github.io/articles/uniformdistn-on-sphere/

--- a/src/gstools/tools/geometric.py
+++ b/src/gstools/tools/geometric.py
@@ -86,7 +86,7 @@ def set_angles(dim, angles):
         out_angles,
         (0, no_of_angles(dim) - len(out_angles)),
         "constant",
-        constant_values=0.0,
+        constant_values=0,
     )
     return out_angles
 
@@ -250,7 +250,7 @@ def matrix_isotropify(dim, anis):
             Stretching matrix.
     """
     anis = set_anis(dim, anis)
-    return np.diag(np.concatenate(([1.0], 1.0 / anis)))
+    return np.diag(np.concatenate(([1], 1 / anis)))
 
 
 def matrix_anisotropify(dim, anis):
@@ -269,7 +269,7 @@ def matrix_anisotropify(dim, anis):
             Stretching matrix.
     """
     anis = set_anis(dim, anis)
-    return np.diag(np.concatenate(([1.0], anis)))
+    return np.diag(np.concatenate(([1], anis)))
 
 
 def matrix_isometrize(dim, angles, anis):
@@ -668,7 +668,7 @@ def latlon2pos(
 
 
 def pos2latlon(
-    pos, radius=1.0, dtype=np.double, temporal=False, time_scale=1.0
+    pos, radius=1, dtype=np.double, temporal=False, time_scale=1
 ):
     """Convert 3D position tuple from sphere to lat-lon geo coordinates.
 
@@ -697,7 +697,7 @@ def pos2latlon(
     """
     pos = np.asarray(pos, dtype=dtype).reshape((4 if temporal else 3, -1))
     # prevent numerical errors in arcsin
-    lat = np.arcsin(np.maximum(np.minimum(pos[2] / radius, 1.0), -1.0))
+    lat = np.arcsin(np.maximum(np.minimum(pos[2] / radius, 1), -1))
     lon = np.arctan2(pos[1], pos[0])
     latlon = np.rad2deg((lat, lon), dtype=dtype)
     if temporal:

--- a/src/gstools/tools/special.py
+++ b/src/gstools/tools/special.py
@@ -116,8 +116,8 @@ def exp_int(s, x):
     x_inf = x > max(30, -s / 2)  # function is like exp(-x)*(1/x + s/x^2)
     x_fin = np.logical_not(np.logical_or(x_zero, x_inf))
     x_fin_pos = np.logical_and(x_fin, np.logical_not(x_neg))
-    if s > 1.0:  # limit at x=+0
-        res[x_zero] = 1.0 / (s - 1.0)
+    if s > 1:  # limit at x=+0
+        res[x_zero] = 1 / (s - 1)
     else:
         res[x_zero] = np.inf
     res[x_inf] = np.exp(-x[x_inf]) * (x[x_inf] ** -1 - s * x[x_inf] ** -2)
@@ -198,15 +198,15 @@ def tpl_exp_spec_dens(k, dim, len_scale, hurst, len_low=0.0):
     :class:`float`
         spectral density of the TPLExponential model
     """
-    if np.isclose(len_low, 0.0):
+    if np.isclose(len_low, 0):
         k = np.asarray(k, dtype=np.double)
         z = (k * len_scale) ** 2
-        a = hurst + dim / 2.0
+        a = hurst + dim / 2
         b = hurst + 0.5
-        c = hurst + dim / 2.0 + 1.0
-        d = dim / 2.0 + 0.5
+        c = hurst + dim / 2 + 1
+        d = dim / 2 + 0.5
         fac = len_scale**dim * hurst * sps.gamma(d) / (np.pi**d * a)
-        return fac / (1.0 + z) ** a * sps.hyp2f1(a, b, c, z / (1.0 + z))
+        return fac / (1 + z) ** a * sps.hyp2f1(a, b, c, z / (1 + z))
     fac_up = (len_scale + len_low) ** (2 * hurst)
     spec_up = tpl_exp_spec_dens(k, dim, len_scale + len_low, hurst)
     fac_low = len_low ** (2 * hurst)
@@ -214,7 +214,7 @@ def tpl_exp_spec_dens(k, dim, len_scale, hurst, len_low=0.0):
     return (fac_up * spec_up - fac_low * spec_low) / (fac_up - fac_low)
 
 
-def tpl_gau_spec_dens(k, dim, len_scale, hurst, len_low=0.0):
+def tpl_gau_spec_dens(k, dim, len_scale, hurst, len_low=0):
     r"""
     Spectral density of the TPLGaussian covariance model.
 
@@ -237,17 +237,17 @@ def tpl_gau_spec_dens(k, dim, len_scale, hurst, len_low=0.0):
     :class:`float`
         spectral density of the TPLExponential model
     """
-    if np.isclose(len_low, 0.0):
+    if np.isclose(len_low, 0):
         k = np.asarray(k, dtype=np.double)
-        z = np.array((k * len_scale / 2.0) ** 2)
+        z = np.array((k * len_scale / 2) ** 2)
         res = np.empty_like(z)
         z_gz = z > 0.1  # greater zero
         z_nz = np.logical_not(z_gz)  # near zero
-        a = hurst + dim / 2.0
-        fac = (len_scale / 2.0) ** dim * hurst / np.pi ** (dim / 2.0)
+        a = hurst + dim / 2
+        fac = (len_scale / 2) ** dim * hurst / np.pi ** (dim / 2)
         res[z_gz] = fac * inc_gamma_low(a, z[z_gz]) / z[z_gz] ** a
         # first order approximation for z near zero
-        res[z_nz] = fac * (1.0 / a - z[z_nz] / (a + 1.0))
+        res[z_nz] = fac * (1 / a - z[z_nz] / (a + 1))
         return res
     fac_up = (len_scale + len_low) ** (2 * hurst)
     spec_up = tpl_gau_spec_dens(k, dim, len_scale + len_low, hurst)

--- a/src/gstools/transform/array.py
+++ b/src/gstools/transform/array.py
@@ -282,8 +282,8 @@ def array_to_arcsin(field, mean=None, var=None, a=None, b=None):
     field = np.asarray(field)
     mean = np.mean(field) if mean is None else float(mean)
     var = np.var(field) if var is None else float(var)
-    a = mean - np.sqrt(2.0 * var) if a is None else float(a)
-    b = mean + np.sqrt(2.0 * var) if b is None else float(b)
+    a = mean - np.sqrt(2 * var) if a is None else float(a)
+    b = mean + np.sqrt(2 * var) if b is None else float(b)
     return _uniform_to_arcsin(array_to_uniform(field, mean, var), a, b)
 
 
@@ -319,8 +319,8 @@ def array_to_uquad(field, mean=None, var=None, a=None, b=None):
     field = np.asarray(field)
     mean = np.mean(field) if mean is None else float(mean)
     var = np.var(field) if var is None else float(var)
-    a = mean - np.sqrt(5.0 / 3.0 * var) if a is None else float(a)
-    b = mean + np.sqrt(5.0 / 3.0 * var) if b is None else float(b)
+    a = mean - np.sqrt(5 / 3 * var) if a is None else float(a)
+    b = mean + np.sqrt(5 / 3 * var) if b is None else float(b)
     return _uniform_to_uquad(array_to_uniform(field, mean, var), a, b)
 
 

--- a/src/gstools/variogram/variogram.py
+++ b/src/gstools/variogram/variogram.py
@@ -263,7 +263,7 @@ def vario_estimate(
     """
     if bin_edges is not None:
         bin_edges = np.array(bin_edges, ndmin=1, dtype=np.double, copy=False)
-        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
+        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
     # allow multiple fields at same positions (ndmin=2: first axis -> field ID)
     # need to convert to ma.array, since list of ma.array is not recognised
     field = np.ma.array(field, ndmin=2, dtype=np.double, copy=True)
@@ -335,7 +335,7 @@ def vario_estimate(
         # only unit-vectors for directions
         direction = np.divide(direction, norms[:, np.newaxis])
         # negative bandwidth to turn it off
-        bandwidth = float(bandwidth) if bandwidth is not None else -1.0
+        bandwidth = float(bandwidth) if bandwidth is not None else -1
         angles_tol = float(angles_tol)
     # prepare sampled variogram
     if sampling_size is not None and sampling_size < pnt_cnt:
@@ -349,7 +349,7 @@ def vario_estimate(
         bin_edges = standard_bins(
             pos, dim, latlon, geo_scale=geo_scale, **std_bins
         )
-        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.0
+        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
     if latlon:
         # internally we always use radians
         bin_edges /= geo_scale

--- a/tests/test_covmodel.py
+++ b/tests/test_covmodel.py
@@ -35,7 +35,7 @@ from gstools.covmodel.tools import (
 class Gau_var(CovModel):
     def variogram(self, r):
         h = np.abs(r) / self.len_rescaled
-        return self.var * (1.0 - np.exp(-(h**2))) + self.nugget
+        return self.var * (1 - np.exp(-(h**2))) + self.nugget
 
 
 class Gau_cov(CovModel):
@@ -60,7 +60,7 @@ class Gau_fix(CovModel):
 
 class Mod_add(CovModel):
     def cor(self, h):
-        return 1.0
+        return 1
 
     def default_opt_arg(self):
         return {"alpha": 1}
@@ -179,7 +179,7 @@ class TestCovModel(unittest.TestCase):
                             if model.has_cdf:
                                 model.spectral_rad_cdf([0, 1])
                             if model.has_ppf:
-                                model.spectral_rad_ppf([0.0, 0.99])
+                                model.spectral_rad_ppf([0, 0.99])
                             model.pykrige_kwargs
                             # check arg bound setting
                             model.set_arg_bounds(
@@ -193,7 +193,7 @@ class TestCovModel(unittest.TestCase):
             for dim in self.dims:
                 model = Model(dim=dim, len_scale=9, len_low=1, rescale=2)
                 self.assertAlmostEqual(model.len_up_rescaled, 5)
-                model.len_low = 0.0
+                model.len_low = 0
                 self.assertAlmostEqual(model.cor(2), model.correlation(9))
                 # also check resetting of var when sill is given lower
                 model.fit_variogram(
@@ -215,7 +215,7 @@ class TestCovModel(unittest.TestCase):
             for dim in self.dims:
                 model = Model(dim=dim)
                 model.fit_variogram(self.gamma_x, self.gamma_y, nugget=False)
-                self.assertAlmostEqual(model.nugget, 0.0)
+                self.assertAlmostEqual(model.nugget, 0)
                 model = Model(dim=dim)
                 # also check resetting of var when sill is given lower
                 model.fit_variogram(self.gamma_x, self.gamma_y, sill=0.9)
@@ -225,7 +225,7 @@ class TestCovModel(unittest.TestCase):
                 model.fit_variogram(
                     self.gamma_x, self.gamma_y, sill=2, nugget=False
                 )
-                self.assertAlmostEqual(model.var, 2.0)
+                self.assertAlmostEqual(model.var, 2)
                 model = Model(dim=dim)
                 model.fit_variogram(
                     self.gamma_x, self.gamma_y, sill=2, nugget=1
@@ -359,13 +359,13 @@ class TestCovModel(unittest.TestCase):
         self.assertRaises(ValueError, Gaussian, dim=0)
         self.assertRaises(ValueError, Gau_fix, latlon=True)
         # check inputs
-        self.assertRaises(ValueError, model_std.percentile_scale, per=-1.0)
-        self.assertRaises(ValueError, Gaussian, anis=-1.0)
+        self.assertRaises(ValueError, model_std.percentile_scale, per=-1)
+        self.assertRaises(ValueError, Gaussian, anis=-1)
         self.assertRaises(ValueError, Gaussian, len_scale=[1, -1])
         self.assertRaises(ValueError, check_arg_in_bounds, model_std, "wrong")
-        self.assertWarns(AttributeWarning, Gaussian, wrong_arg=1.0)
+        self.assertWarns(AttributeWarning, Gaussian, wrong_arg=1)
         with self.assertWarns(AttributeWarning):
-            self.assertRaises(ValueError, Gaussian, len_rescaled=1.0)
+            self.assertRaises(ValueError, Gaussian, len_rescaled=1)
 
         # check correct subclassing
         with self.assertRaises(TypeError):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -33,7 +33,7 @@ class TestExport(unittest.TestCase):
         x = rng.randint(0, 100, size=1000)
         y = rng.randint(0, 100, size=1000)
         model = Exponential(
-            dim=2, var=1, len_scale=[12.0, 3.0], angles=np.pi / 8.0
+            dim=2, var=1, len_scale=[12, 3], angles=np.pi / 8
         )
         self.srf_unstructured = SRF(model, seed=20170519)
         self.srf_unstructured([x, y])

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -12,11 +12,11 @@ import gstools as gs
 
 class TestField(unittest.TestCase):
     def setUp(self):
-        self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4.0)
+        self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4)
         rng = np.random.RandomState(123018)
-        x = rng.uniform(0.0, 10, 100)
-        y = rng.uniform(0.0, 10, 100)
-        self.field = rng.uniform(0.0, 10, 100)
+        x = rng.uniform(0, 10, 100)
+        y = rng.uniform(0, 10, 100)
+        self.field = rng.uniform(0, 10, 100)
         self.pos = np.array([x, y])
 
     def test_standalone(self):

--- a/tests/test_incomprrandmeth.py
+++ b/tests/test_incomprrandmeth.py
@@ -17,12 +17,12 @@ class TestIncomprRandMeth(unittest.TestCase):
         self.cov_model_3d = copy.deepcopy(self.cov_model_2d)
         self.cov_model_3d.dim = 3
         self.seed = 19031977
-        self.x_grid = np.linspace(0.0, 10.0, 9)
-        self.y_grid = np.linspace(-5.0, 5.0, 16)
-        self.z_grid = np.linspace(-6.0, 7.0, 8)
-        self.x_tuple = np.linspace(0.0, 10.0, 10)
-        self.y_tuple = np.linspace(-5.0, 5.0, 10)
-        self.z_tuple = np.linspace(-6.0, 8.0, 10)
+        self.x_grid = np.linspace(0, 10, 9)
+        self.y_grid = np.linspace(-5, 5, 16)
+        self.z_grid = np.linspace(-6, 7, 8)
+        self.x_tuple = np.linspace(0, 10, 10)
+        self.y_tuple = np.linspace(-5, 5, 10)
+        self.z_tuple = np.linspace(-6, 8, 10)
 
         self.rm_2d = IncomprRandMeth(
             self.cov_model_2d, mode_no=100, seed=self.seed

--- a/tests/test_krige.py
+++ b/tests/test_krige.py
@@ -70,7 +70,7 @@ class TestKrige(unittest.TestCase):
                 field_1 = field_1.reshape(self.grid_shape[:dim])
                 field_2, __ = simple.structured(self.pos[:dim])
                 self.assertAlmostEqual(
-                    np.max(np.abs(field_1 - field_2)), 0.0, places=2
+                    np.max(np.abs(field_1 - field_2)), 0, places=2
                 )
                 for i, val in enumerate(self.cond_val):
                     self.assertAlmostEqual(
@@ -98,7 +98,7 @@ class TestKrige(unittest.TestCase):
                     field_1 = field_1.reshape(self.grid_shape[:dim])
                     field_2, __ = ordinary.structured(self.pos[:dim])
                     self.assertAlmostEqual(
-                        np.max(np.abs(field_1 - field_2)), 0.0, places=2
+                        np.max(np.abs(field_1 - field_2)), 0, places=2
                     )
                     for i, val in enumerate(self.cond_val):
                         self.assertAlmostEqual(
@@ -124,7 +124,7 @@ class TestKrige(unittest.TestCase):
                     field_1 = field_1.reshape(self.grid_shape[:dim])
                     field_2, __ = universal.structured(self.pos[:dim])
                     self.assertAlmostEqual(
-                        np.max(np.abs(field_1 - field_2)), 0.0, places=2
+                        np.max(np.abs(field_1 - field_2)), 0, places=2
                     )
                     for i, val in enumerate(self.cond_val):
                         self.assertAlmostEqual(
@@ -149,7 +149,7 @@ class TestKrige(unittest.TestCase):
                 field_2, __ = detrended.structured(self.pos[:dim])
                 # detrended.plot()
                 self.assertAlmostEqual(
-                    np.max(np.abs(field_1 - field_2)), 0.0, places=2
+                    np.max(np.abs(field_1 - field_2)), 0, places=2
                 )
                 for i, val in enumerate(self.cond_val):
                     self.assertAlmostEqual(
@@ -198,7 +198,7 @@ class TestKrige(unittest.TestCase):
                 )
                 # extdrift.plot()
                 self.assertAlmostEqual(
-                    np.max(np.abs(field_1 - field_2)), 0.0, places=2
+                    np.max(np.abs(field_1 - field_2)), 0, places=2
                 )
                 for i, val in enumerate(self.cond_val):
                     self.assertAlmostEqual(

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -197,7 +197,7 @@ class TestNormalizer(unittest.TestCase):
             fit_variogram=True,
         )
         # test fitting during kriging
-        self.assertTrue(np.abs(krige.normalizer.lmbda - 0.0) < 1e-1)
+        self.assertTrue(np.abs(krige.normalizer.lmbda - 0) < 1e-1)
         self.assertAlmostEqual(krige.model.len_scale, 10.2677, places=4)
         self.assertAlmostEqual(
             krige.model.sill,
@@ -216,7 +216,7 @@ class TestNormalizer(unittest.TestCase):
         self.assertAlmostEqual(model.var, 0.6426670183, places=4)
         self.assertAlmostEqual(model.len_scale, 9.635193952, places=4)
         self.assertAlmostEqual(model.nugget, 0.001617908408, places=4)
-        self.assertAlmostEqual(model.alpha, 2.0, places=4)
+        self.assertAlmostEqual(model.alpha, 2, places=4)
 
 
 if __name__ == "__main__":

--- a/tests/test_randmeth.py
+++ b/tests/test_randmeth.py
@@ -19,12 +19,12 @@ class TestRandMeth(unittest.TestCase):
         self.cov_model_3d = copy.deepcopy(self.cov_model_1d)
         self.cov_model_3d.dim = 3
         self.seed = 19031977
-        self.x_grid = np.linspace(0.0, 10.0, 9)
-        self.y_grid = np.linspace(-5.0, 5.0, 16)
-        self.z_grid = np.linspace(-6.0, 7.0, 8)
-        self.x_tuple = np.linspace(0.0, 10.0, 10)
-        self.y_tuple = np.linspace(-5.0, 5.0, 10)
-        self.z_tuple = np.linspace(-6.0, 8.0, 10)
+        self.x_grid = np.linspace(0, 10, 9)
+        self.y_grid = np.linspace(-5, 5, 16)
+        self.z_grid = np.linspace(-6, 7, 8)
+        self.x_tuple = np.linspace(0, 10, 10)
+        self.y_tuple = np.linspace(-5, 5, 10)
+        self.z_tuple = np.linspace(-6, 8, 10)
 
         self.rm_1d = RandMeth(self.cov_model_1d, mode_no=100, seed=self.seed)
         self.rm_2d = RandMeth(self.cov_model_2d, mode_no=100, seed=self.seed)

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -42,7 +42,7 @@ class TestRNG(unittest.TestCase):
         sphere_coord = self.rng.sample_sphere(dim, self.few_modes)
         self.assertEqual(sphere_coord.shape, (dim, self.few_modes))
         sphere_coord = self.rng.sample_sphere(dim, self.many_modes)
-        self.assertAlmostEqual(np.mean(sphere_coord), 0.0, places=3)
+        self.assertAlmostEqual(np.mean(sphere_coord), 0, places=3)
 
     def test_sample_sphere_2d(self):
         dim = 2
@@ -52,7 +52,7 @@ class TestRNG(unittest.TestCase):
             sphere_coord[0, :] ** 2 + sphere_coord[1, :] ** 2,
         )
         sphere_coord = self.rng.sample_sphere(dim, self.many_modes)
-        self.assertAlmostEqual(np.mean(sphere_coord), 0.0, places=3)
+        self.assertAlmostEqual(np.mean(sphere_coord), 0, places=3)
 
     def test_sample_sphere_3d(self):
         dim = 3
@@ -65,24 +65,24 @@ class TestRNG(unittest.TestCase):
             + sphere_coord[2, :] ** 2,
         )
         sphere_coord = self.rng.sample_sphere(dim, self.many_modes)
-        self.assertAlmostEqual(np.mean(sphere_coord), 0.0, places=3)
+        self.assertAlmostEqual(np.mean(sphere_coord), 0, places=3)
 
     def test_sample_dist(self):
-        model = Gaussian(dim=1, var=3.5, len_scale=8.0)
+        model = Gaussian(dim=1, var=3.5, len_scale=8)
         pdf, cdf, ppf = model.dist_func
         rad = self.rng.sample_dist(
             size=self.few_modes, pdf=pdf, cdf=cdf, ppf=ppf, a=0
         )
         self.assertEqual(rad.shape[0], self.few_modes)
 
-        model = Gaussian(dim=2, var=3.5, len_scale=8.0)
+        model = Gaussian(dim=2, var=3.5, len_scale=8)
         pdf, cdf, ppf = model.dist_func
         rad = self.rng.sample_dist(
             size=self.few_modes, pdf=pdf, cdf=cdf, ppf=ppf, a=0
         )
         self.assertEqual(rad.shape[0], self.few_modes)
 
-        model = Gaussian(dim=3, var=3.5, len_scale=8.0)
+        model = Gaussian(dim=3, var=3.5, len_scale=8)
         pdf, cdf, ppf = model.dist_func
         rad = self.rng.sample_dist(
             size=self.few_modes, pdf=pdf, cdf=cdf, ppf=ppf, a=0

--- a/tests/test_srf.py
+++ b/tests/test_srf.py
@@ -22,23 +22,23 @@ except ImportError:
 
 class TestSRF(unittest.TestCase):
     def setUp(self):
-        self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4.0)
+        self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4)
         self.mean = 0.3
         self.mode_no = 100
 
         self.seed = 825718662
-        self.x_grid = np.linspace(0.0, 12.0, 48)
-        self.y_grid = np.linspace(0.0, 10.0, 46)
-        self.z_grid = np.linspace(0.0, 10.0, 40)
+        self.x_grid = np.linspace(0, 12, 48)
+        self.y_grid = np.linspace(0, 10, 46)
+        self.z_grid = np.linspace(0, 10, 40)
 
-        self.x_grid_c = np.linspace(-6.0, 6.0, 8)
-        self.y_grid_c = np.linspace(-6.0, 6.0, 8)
-        self.z_grid_c = np.linspace(-6.0, 6.0, 8)
+        self.x_grid_c = np.linspace(-6, 6, 8)
+        self.y_grid_c = np.linspace(-6, 6, 8)
+        self.z_grid_c = np.linspace(-6, 6, 8)
 
         rng = np.random.RandomState(123018)
-        self.x_tuple = rng.uniform(0.0, 10, 100)
-        self.y_tuple = rng.uniform(0.0, 10, 100)
-        self.z_tuple = rng.uniform(0.0, 10, 100)
+        self.x_tuple = rng.uniform(0, 10, 100)
+        self.y_tuple = rng.uniform(0, 10, 100)
+        self.z_tuple = rng.uniform(0, 10, 100)
 
     def test_shape_1d(self):
         self.cov_model.dim = 1
@@ -134,7 +134,7 @@ class TestSRF(unittest.TestCase):
         field = srf((x_u, y_u), seed=self.seed, mesh_type="unstructured")
         field_str = np.reshape(field, (y_len, x_len))
 
-        self.cov_model.angles = -np.pi / 2.0
+        self.cov_model.angles = -np.pi / 2
         srf = gs.SRF(self.cov_model, mean=self.mean, mode_no=self.mode_no)
         field_rot = srf((x_u, y_u), seed=self.seed, mesh_type="unstructured")
         field_rot_str = np.reshape(field_rot, (y_len, x_len))
@@ -152,7 +152,7 @@ class TestSRF(unittest.TestCase):
             mesh_type="structured",
         )
 
-        self.cov_model.angles = -np.pi / 2.0
+        self.cov_model.angles = -np.pi / 2
         srf = gs.SRF(self.cov_model, mean=self.mean, mode_no=self.mode_no)
         field_rot = srf(
             (self.x_grid_c, self.y_grid_c),
@@ -181,7 +181,7 @@ class TestSRF(unittest.TestCase):
         field = srf((x_u, y_u, z_u), seed=self.seed, mesh_type="unstructured")
         field_str = np.reshape(field, (y_len, x_len, z_len))
 
-        self.cov_model.angles = (-np.pi / 2.0, -np.pi / 2.0)
+        self.cov_model.angles = (-np.pi / 2, -np.pi / 2)
         srf = gs.SRF(self.cov_model, mean=self.mean, mode_no=self.mode_no)
         field_rot = srf(
             (x_u, y_u, z_u), seed=self.seed, mesh_type="unstructured"
@@ -202,7 +202,7 @@ class TestSRF(unittest.TestCase):
             mesh_type="structured",
         )
 
-        self.cov_model.angles = -np.pi / 2.0
+        self.cov_model.angles = -np.pi / 2
         srf = gs.SRF(self.cov_model, mean=self.mean, mode_no=self.mode_no)
         field_rot = srf(
             (self.x_grid_c, self.y_grid_c, self.z_grid_c),
@@ -213,7 +213,7 @@ class TestSRF(unittest.TestCase):
         self.assertAlmostEqual(field[0, 0, 0], field_rot[0, 7, 0])
         self.assertAlmostEqual(field[0, 0, 1], field_rot[0, 7, 1])
 
-        self.cov_model.angles = (0, -np.pi / 2.0)
+        self.cov_model.angles = (0, -np.pi / 2)
         srf = gs.SRF(self.cov_model, mean=self.mean, mode_no=self.mode_no)
         field_rot = srf(
             (self.x_grid_c, self.y_grid_c, self.z_grid_c),

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -8,13 +8,13 @@ import gstools as gs
 
 class TestTransform(unittest.TestCase):
     def setUp(self):
-        self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4.0)
+        self.cov_model = gs.Gaussian(dim=2, var=1.5, len_scale=4)
         self.mean = 0.3
         self.mode_no = 100
 
         self.seed = 825718662
-        self.x_grid = np.linspace(0.0, 12.0, 48)
-        self.y_grid = np.linspace(0.0, 10.0, 46)
+        self.x_grid = np.linspace(0, 12, 48)
+        self.y_grid = np.linspace(0, 10, 46)
 
         self.methods = [
             "binary",
@@ -68,7 +68,7 @@ class TestTransform(unittest.TestCase):
         srf.transform(
             "discrete", values=values, thresholds="arithmetic", store="f2"
         )
-        np.testing.assert_allclose(np.unique(srf.f2), [-1.0, 0.0, 1.0])
+        np.testing.assert_allclose(np.unique(srf.f2), [-1, 0, 1])
 
         values = [-1, 0, 0.5, 1]
         srf.transform(
@@ -171,7 +171,7 @@ class TestTransform(unittest.TestCase):
             store="f2",
             process=True,
         )
-        np.testing.assert_allclose(np.unique(np.log(srf.f2)), [-1.0, 0.0, 1.0])
+        np.testing.assert_allclose(np.unique(np.log(srf.f2)), [-1, 0, 1])
 
         values = [-1, 0, 0.5, 1]
         srf.transform(

--- a/tests/test_variogram_structured.py
+++ b/tests/test_variogram_structured.py
@@ -24,7 +24,7 @@ class TestVariogramStructured(unittest.TestCase):
     def test_ints(self):
         z = np.array((10, 20, 30, 40), dtype=int)
         gamma = gs.vario_estimate_axis(z)
-        self.assertAlmostEqual(gamma[1], 50.0, places=4)
+        self.assertAlmostEqual(gamma[1], 50, places=4)
 
     def test_mixed(self):
         z = np.array(
@@ -37,7 +37,7 @@ class TestVariogramStructured(unittest.TestCase):
         z = np.array((10, 20, 30, 40), dtype=int)
 
         gamma = gs.vario_estimate_axis(z)
-        self.assertAlmostEqual(gamma[1], 50.0, places=4)
+        self.assertAlmostEqual(gamma[1], 50, places=4)
 
     def test_list(self):
         z = [41.2, 40.2, 39.7, 39.2, 40.1, 38.3, 39.1, 40.0, 41.1, 40.3]
@@ -47,7 +47,7 @@ class TestVariogramStructured(unittest.TestCase):
     def test_cressie_1d(self):
         z = [41.2, 40.2, 39.7, 39.2, 40.1, 38.3, 39.1, 40.0, 41.1, 40.3]
         gamma = gs.vario_estimate_axis(z, estimator="cressie")
-        self.assertAlmostEqual(gamma[1], 1.546 / 2.0, places=3)
+        self.assertAlmostEqual(gamma[1], 1.546 / 2, places=3)
 
     def test_1d(self):
         # literature values
@@ -86,11 +86,11 @@ class TestVariogramStructured(unittest.TestCase):
         gamma_x = gs.vario_estimate_axis(field_ma, direction="x")
         gamma_y = gs.vario_estimate_axis(field_ma, direction="y")
 
-        var = 1.0 / 12.0
-        self.assertAlmostEqual(gamma_x[0], 0.0, places=2)
+        var = 1 / 12
+        self.assertAlmostEqual(gamma_x[0], 0, places=2)
         self.assertAlmostEqual(gamma_x[len(gamma_x) // 2], var, places=2)
         self.assertAlmostEqual(gamma_x[-1], var, places=2)
-        self.assertAlmostEqual(gamma_y[0], 0.0, places=2)
+        self.assertAlmostEqual(gamma_y[0], 0, places=2)
         self.assertAlmostEqual(gamma_y[len(gamma_y) // 2], var, places=2)
         self.assertAlmostEqual(gamma_y[-1], var, places=2)
 
@@ -99,8 +99,8 @@ class TestVariogramStructured(unittest.TestCase):
         field = np.ma.masked_array(field, mask=mask)
         gamma_x = gs.vario_estimate_axis(field_ma, direction="x")
         gamma_y = gs.vario_estimate_axis(field_ma, direction="y")
-        self.assertAlmostEqual(gamma_x[0], 0.0, places=2)
-        self.assertAlmostEqual(gamma_y[0], 0.0, places=2)
+        self.assertAlmostEqual(gamma_x[0], 0, places=2)
+        self.assertAlmostEqual(gamma_y[0], 0, places=2)
 
     def test_masked_3d(self):
         rng = np.random.RandomState(1479373475)
@@ -112,14 +112,14 @@ class TestVariogramStructured(unittest.TestCase):
         gamma_y = gs.vario_estimate_axis(field_ma, direction="y")
         gamma_z = gs.vario_estimate_axis(field_ma, direction="z")
 
-        var = 1.0 / 12.0
-        self.assertAlmostEqual(gamma_x[0], 0.0, places=2)
+        var = 1 / 12
+        self.assertAlmostEqual(gamma_x[0], 0, places=2)
         self.assertAlmostEqual(gamma_x[len(gamma_x) // 2], var, places=2)
         self.assertAlmostEqual(gamma_x[-1], var, places=2)
-        self.assertAlmostEqual(gamma_y[0], 0.0, places=2)
+        self.assertAlmostEqual(gamma_y[0], 0, places=2)
         self.assertAlmostEqual(gamma_y[len(gamma_y) // 2], var, places=2)
         self.assertAlmostEqual(gamma_y[-1], var, places=2)
-        self.assertAlmostEqual(gamma_z[0], 0.0, places=2)
+        self.assertAlmostEqual(gamma_z[0], 0, places=2)
         self.assertAlmostEqual(gamma_z[len(gamma_y) // 2], var, places=2)
         self.assertAlmostEqual(gamma_z[-1], var, places=2)
 
@@ -129,13 +129,13 @@ class TestVariogramStructured(unittest.TestCase):
         gamma_x = gs.vario_estimate_axis(field_ma, direction="x")
         gamma_y = gs.vario_estimate_axis(field_ma, direction="y")
         gamma_z = gs.vario_estimate_axis(field_ma, direction="z")
-        self.assertAlmostEqual(gamma_x[0], 0.0, places=2)
-        self.assertAlmostEqual(gamma_y[0], 0.0, places=2)
-        self.assertAlmostEqual(gamma_z[0], 0.0, places=2)
+        self.assertAlmostEqual(gamma_x[0], 0, places=2)
+        self.assertAlmostEqual(gamma_y[0], 0, places=2)
+        self.assertAlmostEqual(gamma_z[0], 0, places=2)
 
     def test_uncorrelated_2d(self):
-        x = np.linspace(0.0, 100.0, 80)
-        y = np.linspace(0.0, 100.0, 60)
+        x = np.linspace(0, 100, 80)
+        y = np.linspace(0, 100, 60)
 
         rng = np.random.RandomState(1479373475)
         field = rng.rand(len(x), len(y))
@@ -143,17 +143,17 @@ class TestVariogramStructured(unittest.TestCase):
         gamma_x = gs.vario_estimate_axis(field, direction="x")
         gamma_y = gs.vario_estimate_axis(field, direction="y")
 
-        var = 1.0 / 12.0
-        self.assertAlmostEqual(gamma_x[0], 0.0, places=2)
+        var = 1 / 12
+        self.assertAlmostEqual(gamma_x[0], 0, places=2)
         self.assertAlmostEqual(gamma_x[len(gamma_x) // 2], var, places=2)
         self.assertAlmostEqual(gamma_x[-1], var, places=2)
-        self.assertAlmostEqual(gamma_y[0], 0.0, places=2)
+        self.assertAlmostEqual(gamma_y[0], 0, places=2)
         self.assertAlmostEqual(gamma_y[len(gamma_y) // 2], var, places=2)
         self.assertAlmostEqual(gamma_y[-1], var, places=2)
 
     def test_uncorrelated_cressie_2d(self):
-        x = np.linspace(0.0, 100.0, 80)
-        y = np.linspace(0.0, 100.0, 60)
+        x = np.linspace(0, 100, 80)
+        y = np.linspace(0, 100, 60)
 
         rng = np.random.RandomState(1479373475)
         field = rng.rand(len(x), len(y))
@@ -165,16 +165,16 @@ class TestVariogramStructured(unittest.TestCase):
             field, direction="y", estimator="cressie"
         )
 
-        var = 1.0 / 12.0
-        self.assertAlmostEqual(gamma_x[0], 0.0, places=1)
+        var = 1 / 12
+        self.assertAlmostEqual(gamma_x[0], 0, places=1)
         self.assertAlmostEqual(gamma_x[len(gamma_x) // 2], var, places=1)
-        self.assertAlmostEqual(gamma_y[0], 0.0, places=1)
+        self.assertAlmostEqual(gamma_y[0], 0, places=1)
         self.assertAlmostEqual(gamma_y[len(gamma_y) // 2], var, places=1)
 
     def test_uncorrelated_3d(self):
-        x = np.linspace(0.0, 100.0, 30)
-        y = np.linspace(0.0, 100.0, 30)
-        z = np.linspace(0.0, 100.0, 30)
+        x = np.linspace(0, 100, 30)
+        y = np.linspace(0, 100, 30)
+        z = np.linspace(0, 100, 30)
 
         rng = np.random.RandomState(1479373475)
         field = rng.rand(len(x), len(y), len(z))
@@ -183,14 +183,14 @@ class TestVariogramStructured(unittest.TestCase):
         gamma = gs.vario_estimate_axis(field, "y")
         gamma = gs.vario_estimate_axis(field, "z")
 
-        var = 1.0 / 12.0
-        self.assertAlmostEqual(gamma[0], 0.0, places=2)
+        var = 1 / 12
+        self.assertAlmostEqual(gamma[0], 0, places=2)
         self.assertAlmostEqual(gamma[len(gamma) // 2], var, places=2)
         self.assertAlmostEqual(gamma[-1], var, places=2)
 
     def test_directions_2d(self):
-        x = np.linspace(0.0, 20.0, 100)
-        y = np.linspace(0.0, 15.0, 80)
+        x = np.linspace(0, 20, 100)
+        y = np.linspace(0, 15, 80)
         rng = np.random.RandomState(1479373475)
         x_rand = rng.rand(len(x))
         y_rand = rng.rand(len(y))
@@ -205,17 +205,17 @@ class TestVariogramStructured(unittest.TestCase):
         gamma_y_x = gs.vario_estimate_axis(field_y, direction="x")
         # gamma_y_y = gs.vario_estimate_axis(field_y, direction="y")
 
-        self.assertAlmostEqual(gamma_x_y[1], 0.0)
-        self.assertAlmostEqual(gamma_x_y[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_x_y[-1], 0.0)
-        self.assertAlmostEqual(gamma_y_x[1], 0.0)
-        self.assertAlmostEqual(gamma_y_x[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_y_x[-1], 0.0)
+        self.assertAlmostEqual(gamma_x_y[1], 0)
+        self.assertAlmostEqual(gamma_x_y[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_x_y[-1], 0)
+        self.assertAlmostEqual(gamma_y_x[1], 0)
+        self.assertAlmostEqual(gamma_y_x[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_y_x[-1], 0)
 
     def test_directions_3d(self):
-        x = np.linspace(0.0, 10.0, 20)
-        y = np.linspace(0.0, 15.0, 25)
-        z = np.linspace(0.0, 20.0, 30)
+        x = np.linspace(0, 10, 20)
+        y = np.linspace(0, 15, 25)
+        z = np.linspace(0, 20, 30)
         rng = np.random.RandomState(1479373475)
         x_rand = rng.rand(len(x))
         y_rand = rng.rand(len(y))
@@ -237,33 +237,33 @@ class TestVariogramStructured(unittest.TestCase):
         gamma_z_y = gs.vario_estimate_axis(field_z, direction="y")
         # gamma_z_z = gs.vario_estimate_axis(field_z, direction="z")
 
-        self.assertAlmostEqual(gamma_x_y[1], 0.0)
-        self.assertAlmostEqual(gamma_x_y[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_x_y[-1], 0.0)
-        self.assertAlmostEqual(gamma_x_z[1], 0.0)
-        self.assertAlmostEqual(gamma_x_z[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_x_z[-1], 0.0)
-        self.assertAlmostEqual(gamma_y_x[1], 0.0)
-        self.assertAlmostEqual(gamma_y_x[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_y_x[-1], 0.0)
-        self.assertAlmostEqual(gamma_y_z[1], 0.0)
-        self.assertAlmostEqual(gamma_y_z[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_y_z[-1], 0.0)
-        self.assertAlmostEqual(gamma_z_x[1], 0.0)
-        self.assertAlmostEqual(gamma_z_x[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_z_x[-1], 0.0)
-        self.assertAlmostEqual(gamma_z_y[1], 0.0)
-        self.assertAlmostEqual(gamma_z_y[len(gamma_x_y) // 2], 0.0)
-        self.assertAlmostEqual(gamma_z_y[-1], 0.0)
+        self.assertAlmostEqual(gamma_x_y[1], 0)
+        self.assertAlmostEqual(gamma_x_y[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_x_y[-1], 0)
+        self.assertAlmostEqual(gamma_x_z[1], 0)
+        self.assertAlmostEqual(gamma_x_z[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_x_z[-1], 0)
+        self.assertAlmostEqual(gamma_y_x[1], 0)
+        self.assertAlmostEqual(gamma_y_x[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_y_x[-1], 0)
+        self.assertAlmostEqual(gamma_y_z[1], 0)
+        self.assertAlmostEqual(gamma_y_z[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_y_z[-1], 0)
+        self.assertAlmostEqual(gamma_z_x[1], 0)
+        self.assertAlmostEqual(gamma_z_x[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_z_x[-1], 0)
+        self.assertAlmostEqual(gamma_z_y[1], 0)
+        self.assertAlmostEqual(gamma_z_y[len(gamma_x_y) // 2], 0)
+        self.assertAlmostEqual(gamma_z_y[-1], 0)
 
     def test_exceptions(self):
-        x = np.linspace(0.0, 10.0, 20)
+        x = np.linspace(0, 10, 20)
         # rng = np.random.RandomState(1479373475)
         # x_rand = rng.rand(len(x))
         self.assertRaises(ValueError, gs.vario_estimate_axis, x, "a")
 
     def test_missing(self):
-        x = np.linspace(0.0, 10.0, 10)
+        x = np.linspace(0, 10, 10)
         x_nan = x.copy()
         x_nan[0] = np.nan
         x_mask = np.isnan(x_nan)

--- a/tests/test_variogram_unstructured.py
+++ b/tests/test_variogram_unstructured.py
@@ -32,7 +32,7 @@ class TestVariogramUnstructured(unittest.TestCase):
         z = np.array((10, 20, 30, 40), dtype=int)
         bins = np.arange(1, 11, 1, dtype=int)
         bin_centres, gamma = gs.vario_estimate([x], z, bins)
-        self.assertAlmostEqual(gamma[0], 50.0, places=4)
+        self.assertAlmostEqual(gamma[0], 50, places=4)
 
     def test_mixed(self):
         x = np.arange(1, 11, 1, dtype=np.double)
@@ -48,13 +48,13 @@ class TestVariogramUnstructured(unittest.TestCase):
         z = np.array((10, 20, 30, 40), dtype=int)
         bins = np.arange(1, 11, 1, dtype=int)
         bin_centres, gamma = gs.vario_estimate([x], z, bins)
-        self.assertAlmostEqual(gamma[0], 50.0, places=4)
+        self.assertAlmostEqual(gamma[0], 50, places=4)
 
         x = np.arange(1, 5, 1, dtype=np.double)
         z = np.array((10, 20, 30, 40), dtype=int)
         bins = np.arange(1, 11, 1, dtype=np.double)
         bin_centres, gamma = gs.vario_estimate([x], z, bins)
-        self.assertAlmostEqual(gamma[0], 50.0, places=4)
+        self.assertAlmostEqual(gamma[0], 50, places=4)
 
     def test_list(self):
         x = np.arange(1, 11, 1, dtype=np.double)
@@ -76,8 +76,8 @@ class TestVariogramUnstructured(unittest.TestCase):
         self.assertAlmostEqual(gamma[1], 0.7625, places=4)
 
     def test_uncorrelated_2d(self):
-        x_c = np.linspace(0.0, 100.0, 60)
-        y_c = np.linspace(0.0, 100.0, 60)
+        x_c = np.linspace(0, 100, 60)
+        y_c = np.linspace(0, 100, 60)
         x, y = np.meshgrid(x_c, y_c)
         x = np.reshape(x, len(x_c) * len(y_c))
         y = np.reshape(y, len(x_c) * len(y_c))
@@ -89,15 +89,15 @@ class TestVariogramUnstructured(unittest.TestCase):
 
         bin_centres, gamma = gs.vario_estimate((x, y), field, bins)
 
-        var = 1.0 / 12.0
+        var = 1 / 12
         self.assertAlmostEqual(gamma[0], var, places=2)
         self.assertAlmostEqual(gamma[len(gamma) // 2], var, places=2)
         self.assertAlmostEqual(gamma[-1], var, places=2)
 
     def test_uncorrelated_3d(self):
-        x_c = np.linspace(0.0, 100.0, 15)
-        y_c = np.linspace(0.0, 100.0, 15)
-        z_c = np.linspace(0.0, 100.0, 15)
+        x_c = np.linspace(0, 100, 15)
+        y_c = np.linspace(0, 100, 15)
+        z_c = np.linspace(0, 100, 15)
         x, y, z = np.meshgrid(x_c, y_c, z_c)
         x = np.reshape(x, len(x_c) * len(y_c) * len(z_c))
         y = np.reshape(y, len(x_c) * len(y_c) * len(z_c))
@@ -110,13 +110,13 @@ class TestVariogramUnstructured(unittest.TestCase):
 
         bin_centres, gamma = gs.vario_estimate((x, y, z), field, bins)
 
-        var = 1.0 / 12.0
+        var = 1 / 12
         self.assertAlmostEqual(gamma[0], var, places=2)
         self.assertAlmostEqual(gamma[len(gamma) // 2], var, places=2)
         self.assertAlmostEqual(gamma[-1], var, places=2)
 
     def test_sampling_1d(self):
-        x = np.linspace(0.0, 100.0, 21000)
+        x = np.linspace(0, 100, 21000)
 
         rng = np.random.RandomState(1479373475)
         field = rng.rand(len(x))
@@ -127,14 +127,14 @@ class TestVariogramUnstructured(unittest.TestCase):
             [x], field, bins, sampling_size=5000, sampling_seed=1479373475
         )
 
-        var = 1.0 / 12.0
+        var = 1 / 12
         self.assertAlmostEqual(gamma[0], var, places=2)
         self.assertAlmostEqual(gamma[len(gamma) // 2], var, places=2)
         self.assertAlmostEqual(gamma[-1], var, places=2)
 
     def test_sampling_2d(self):
-        x_c = np.linspace(0.0, 100.0, 600)
-        y_c = np.linspace(0.0, 100.0, 600)
+        x_c = np.linspace(0, 100, 600)
+        y_c = np.linspace(0, 100, 600)
         x, y = np.meshgrid(x_c, y_c)
         x = np.reshape(x, len(x_c) * len(y_c))
         y = np.reshape(y, len(x_c) * len(y_c))
@@ -148,15 +148,15 @@ class TestVariogramUnstructured(unittest.TestCase):
             (x, y), field, bins, sampling_size=2000, sampling_seed=1479373475
         )
 
-        var = 1.0 / 12.0
+        var = 1 / 12
         self.assertAlmostEqual(gamma[0], var, places=2)
         self.assertAlmostEqual(gamma[len(gamma) // 2], var, places=2)
         self.assertAlmostEqual(gamma[-1], var, places=2)
 
     def test_sampling_3d(self):
-        x_c = np.linspace(0.0, 100.0, 100)
-        y_c = np.linspace(0.0, 100.0, 100)
-        z_c = np.linspace(0.0, 100.0, 100)
+        x_c = np.linspace(0, 100, 100)
+        y_c = np.linspace(0, 100, 100)
+        z_c = np.linspace(0, 100, 100)
         x, y, z = np.meshgrid(x_c, y_c, z_c)
         x = np.reshape(x, len(x_c) * len(y_c) * len(z_c))
         y = np.reshape(y, len(x_c) * len(y_c) * len(z_c))
@@ -174,7 +174,7 @@ class TestVariogramUnstructured(unittest.TestCase):
             sampling_size=2000,
             sampling_seed=1479373475,
         )
-        var = 1.0 / 12.0
+        var = 1 / 12
         self.assertAlmostEqual(gamma[0], var, places=2)
         self.assertAlmostEqual(gamma[len(gamma) // 2], var, places=2)
         self.assertAlmostEqual(gamma[-1], var, places=2)
@@ -211,7 +211,7 @@ class TestVariogramUnstructured(unittest.TestCase):
         )
 
     def test_multi_field(self):
-        x = np.random.RandomState(19970221).rand(100) * 100.0
+        x = np.random.RandomState(19970221).rand(100) * 100
         model = gs.Exponential(dim=1, var=2, len_scale=10)
         srf = gs.SRF(model)
         field1 = srf(x, seed=19970221)
@@ -225,8 +225,8 @@ class TestVariogramUnstructured(unittest.TestCase):
             self.assertAlmostEqual(gamma[i], gamma_mean[i], places=2)
 
     def test_no_data(self):
-        x1 = np.random.RandomState(19970221).rand(100) * 100.0
-        field1 = np.random.RandomState(20011012).rand(100) * 100.0
+        x1 = np.random.RandomState(19970221).rand(100) * 100
+        field1 = np.random.RandomState(20011012).rand(100) * 100
         field1[:10] = np.nan
         x2 = x1[10:]
         field2 = field1[10:]
@@ -333,9 +333,9 @@ class TestVariogramUnstructured(unittest.TestCase):
         self.assertAlmostEqual(v1[0], v3[0])
         self.assertEqual(c1[0], c2[0])
         self.assertEqual(c1[0], c3[0])
-        self.assertAlmostEqual(v4[0], 0.0)
+        self.assertAlmostEqual(v4[0], 0)
         self.assertEqual(c4[0], 0)
-        self.assertAlmostEqual(v5[0], 0.0)
+        self.assertAlmostEqual(v5[0], 0)
 
     def test_fit_directional(self):
         model = gs.Stable(dim=3)


### PR DESCRIPTION
Python 2 needed explicit float literals in order to do the correct math. In Python 3 this is not needed anymore. Using integers describes better the intention of the code.

This PR only changes floats that end with `.0` to integers where appropriate.