### PR TITLE
Add a global variable to set number of parallel threads

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,6 +98,8 @@ For the development version, you can do almost the same:
     export GSTOOLS_BUILD_PARALLEL=1
     pip install git+git://github.com/GeoStat-Framework/GSTools.git@main
 
+The number of parallel threads can be set with the global variable `config.NUM_THREADS`.
+
 **Using experimental GSTools-Core for even more speed**
 
 You can install the optional dependency `GSTools-Core <https://github.com/GeoStat-Framework/GSTools-Core>`_,

--- a/src/gstools/config.py
+++ b/src/gstools/config.py
@@ -4,6 +4,8 @@ GStools subpackage providing global variables.
 .. currentmodule:: gstools.config
 
 """
+NUM_THREADS = 1
+
 # pylint: disable=W0611
 try:  # pragma: no cover
     import gstools_core

--- a/src/gstools/field/generator.py
+++ b/src/gstools/field/generator.py
@@ -209,7 +209,9 @@ class RandMeth(Generator):
             the random modes
         """
         pos = np.asarray(pos, dtype=np.double)
-        summed_modes = summate(self._cov_sample, self._z_1, self._z_2, pos)
+        summed_modes = summate(
+            self._cov_sample, self._z_1, self._z_2, pos, config.NUM_THREADS
+        )
         nugget = self.get_nugget(summed_modes.shape) if add_nugget else 0.0
         return np.sqrt(self.model.var / self._mode_no) * summed_modes + nugget
 
@@ -489,7 +491,11 @@ class IncomprRandMeth(RandMeth):
         """
         pos = np.asarray(pos, dtype=np.double)
         summed_modes = summate_incompr(
-            self._cov_sample, self._z_1, self._z_2, pos
+            self._cov_sample,
+            self._z_1,
+            self._z_2,
+            pos,
+            config.NUM_THREADS,
         )
         nugget = self.get_nugget(summed_modes.shape) if add_nugget else 0.0
         e1 = self._create_unit_vector(summed_modes.shape)

--- a/src/gstools/field/summator.pyx
+++ b/src/gstools/field/summator.pyx
@@ -14,7 +14,8 @@ def summate(
     const double[:, :] cov_samples,
     const double[:] z_1,
     const double[:] z_2,
-    const double[:, :] pos
+    const double[:, :] pos,
+    const int num_threads=1,
 ):
     cdef int i, j, d
     cdef double phase
@@ -25,7 +26,7 @@ def summate(
 
     cdef double[:] summed_modes = np.zeros(X_len, dtype=float)
 
-    for i in prange(X_len, nogil=True):
+    for i in prange(X_len, nogil=True, num_threads=num_threads):
         for j in range(N):
             phase = 0.
             for d in range(dim):
@@ -49,7 +50,8 @@ def summate_incompr(
     const double[:, :] cov_samples,
     const double[:] z_1,
     const double[:] z_2,
-    const double[:, :] pos
+    const double[:, :] pos,
+    const int num_threads=1,
 ):
     cdef int i, j, d
     cdef double phase

--- a/src/gstools/krige/krigesum.pyx
+++ b/src/gstools/krige/krigesum.pyx
@@ -12,7 +12,8 @@ cimport numpy as np
 def calc_field_krige_and_variance(
     const double[:, :] krig_mat,
     const double[:, :] krig_vecs,
-    const double[:] cond
+    const double[:] cond,
+    const int num_threads=1,
 ):
 
     cdef int mat_i = krig_mat.shape[0]
@@ -26,7 +27,7 @@ def calc_field_krige_and_variance(
 
     # error = krig_vecs * krig_mat * krig_vecs
     # field = cond * krig_mat * krig_vecs
-    for k in prange(res_i, nogil=True):
+    for k in prange(res_i, nogil=True, num_threads=num_threads):
         for i in range(mat_i):
             krig_fac = 0.0
             for j in range(mat_i):
@@ -40,7 +41,8 @@ def calc_field_krige_and_variance(
 def calc_field_krige(
     const double[:, :] krig_mat,
     const double[:, :] krig_vecs,
-    const double[:] cond
+    const double[:] cond,
+    const int num_threads=1,
 ):
 
     cdef int mat_i = krig_mat.shape[0]
@@ -52,7 +54,7 @@ def calc_field_krige(
     cdef int i, j, k
 
     # field = cond * krig_mat * krig_vecs
-    for k in prange(res_i, nogil=True):
+    for k in prange(res_i, nogil=True, num_threads=num_threads):
         for i in range(mat_i):
             krig_fac = 0.0
             for j in range(mat_i):

--- a/src/gstools/variogram/variogram.py
+++ b/src/gstools/variogram/variogram.py
@@ -374,6 +374,7 @@ def vario_estimate(
             pos,
             estimator_type=cython_estimator,
             distance_type=distance_type,
+            num_threads=config.NUM_THREADS,
         )
     else:
         estimates, counts = directional(
@@ -385,6 +386,7 @@ def vario_estimate(
             bandwidth,
             separate_dirs=_separate_dirs_test(direction, angles_tol),
             estimator_type=cython_estimator,
+            num_threads=config.num_threads,
         )
         if dir_no == 1:
             estimates, counts = estimates[0], counts[0]
@@ -485,8 +487,10 @@ def vario_estimate_axis(
     cython_estimator = _set_estimator(estimator)
 
     if masked:
-        return ma_structured(field, mask, cython_estimator)
-    return structured(field, cython_estimator)
+        return ma_structured(
+            field, mask, cython_estimator, num_threads=config.NUM_THREADS
+        )
+    return structured(field, cython_estimator, num_threads=config.NUM_THREADS)
 
 
 # for backward compatibility


### PR DESCRIPTION
As pointed out by [pavlovc2](https://github.com/pavlovc2) in discussion #333, it would be helpful to set the number of parallel threads in GSTools directly and not only rely on environment variables.

I didn't have a lot of time to put this together, but in this first draft, you can set the number of threads with the global variable `config.NUM_THREADS`. At the moment, this only works with the Cython code and not with the Rust code. And also, for now, the default value of threads is 1.

TODO

- [ ] also set the number of threads for the Rust code
- [ ] find out how to set `num_threads=None` in the Cython code