### PR TITLE
perpare v1.5.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest-large, macos-latest]
         # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
         ver:
           - {py: '3.8', np: '==1.20.0', sp: '==1.5.4'}
@@ -96,6 +96,13 @@ jobs:
           - {py: '3.11', np: '==1.23.2', sp: '==1.9.2'}
           - {py: '3.12', np: '==1.26.2', sp: '==1.11.2'}
           - {py: '3.12', np: '>=2.0.0rc1', sp: '>=1.13.0'}
+        exclude:
+          - os: macos-latest
+            ver: {py: '3.8', np: '==1.20.0', sp: '==1.5.4'}
+          - os: macos-latest
+            ver: {py: '3.9', np: '==1.20.0', sp: '==1.5.4'}
+          - os: macos-latest
+            ver: {py: '3.10', np: '==1.21.6', sp: '==1.7.2'}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.18.0
         env:
           CIBW_ARCHS: ${{ matrix.cfg.arch }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,8 @@ jobs:
           cython-lint src/gstools/
 
   build_wheels:
-    name: wheels for ${{ matrix.cfg.os }}
-    runs-on: ${{ matrix.cfg.os }}
+    name: wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,17 +53,13 @@ jobs:
           cython-lint src/gstools/
 
   build_wheels:
-    name: wheels for ${{ matrix.cfg.os }} / ${{ matrix.cfg.arch }}
+    name: wheels for ${{ matrix.cfg.os }}
     runs-on: ${{ matrix.cfg.os }}
     strategy:
       fail-fast: false
       matrix:
-        cfg:
-        - { os: ubuntu-latest, arch: x86_64 }
-        - { os: windows-latest, arch: AMD64 }
-        - { os: macos-latest, arch: x86_64 }
-        - { os: macos-latest, arch: arm64 }
-        - { os: macos-latest, arch: universal2 }
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -72,8 +68,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18.0
-        env:
-          CIBW_ARCHS: ${{ matrix.cfg.arch }}
         with:
           output-dir: dist
 
@@ -87,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
         ver:
           - {py: '3.8', np: '==1.20.0', sp: '==1.5.4'}
@@ -97,11 +91,11 @@ jobs:
           - {py: '3.12', np: '==1.26.2', sp: '==1.11.2'}
           - {py: '3.12', np: '>=2.0.0rc1', sp: '>=1.13.0'}
         exclude:
-          - os: macos-latest
+          - os: macos-14
             ver: {py: '3.8', np: '==1.20.0', sp: '==1.5.4'}
-          - os: macos-latest
+          - os: macos-14
             ver: {py: '3.9', np: '==1.20.0', sp: '==1.5.4'}
-          - os: macos-latest
+          - os: macos-14
             ver: {py: '3.10', np: '==1.21.6', sp: '==1.7.2'}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest-large, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
         ver:
           - {py: '3.8', np: '==1.20.0', sp: '==1.5.4'}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ All notable changes to **GSTools** will be documented in this file.
 ### Bugfixes
 - build docs with latest sphinx version ([#340](https://github.com/GeoStat-Framework/GSTools/pull/340))
 - fixed zero division error in spectral density of Integral model ([#347](https://github.com/GeoStat-Framework/GSTools/pull/347))
+- minor pylint fixes for used-before-assignment issues ([#350](https://github.com/GeoStat-Framework/GSTools/pull/350))
 
 ### Changes
 - require pyvista 0.40 at least ([#340](https://github.com/GeoStat-Framework/GSTools/pull/340))
+- require matplotlib 3.7 at least ([#350](https://github.com/GeoStat-Framework/GSTools/pull/350))
+- remove universal2 wheels for macos (we already provide separate intel and arm64 wheels) ([#350](https://github.com/GeoStat-Framework/GSTools/pull/350))
 
 
 ## [1.5.1] - Nifty Neon - 2023-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to **GSTools** will be documented in this file.
 
-## [Unreleased] - ?
+## [1.5.2] - Nifty Neon - 2024-05
 
 ### Enhancements
 
 - added global variable `config.NUM_THREADS` to select number of threads for parallel computation ([#336](https://github.com/GeoStat-Framework/GSTools/pull/336))
+- speed up sampling with emcee by setting `vectorize=True` in `EnsembleSampler` ([#346](https://github.com/GeoStat-Framework/GSTools/pull/346))
 - prepare numpy 2 support ([#340](https://github.com/GeoStat-Framework/GSTools/pull/340))
-  - numpy 2.0.0rc1 for building extensions (for Python 3.9 and above)
+  - at least numpy 2.0.0rc1 for building extensions (for Python 3.9 and above)
   - check multiple numpy and scipy versions in CI
   - fixed minimal versions for numpy
   - use `np.asarray` everywhere with `np.atleast_(n)d`
@@ -16,6 +17,7 @@ All notable changes to **GSTools** will be documented in this file.
 
 ### Bugfixes
 - build docs with latest sphinx version ([#340](https://github.com/GeoStat-Framework/GSTools/pull/340))
+- fixed zero division error in spectral density of Integral model ([#347](https://github.com/GeoStat-Framework/GSTools/pull/347))
 
 ### Changes
 - require pyvista 0.40 at least ([#340](https://github.com/GeoStat-Framework/GSTools/pull/340))
@@ -435,7 +437,8 @@ See: [#197](https://github.com/GeoStat-Framework/GSTools/issues/197)
 First release of GSTools.
 
 
-[Unreleased]: https://github.com/GeoStat-Framework/gstools/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/GeoStat-Framework/gstools/compare/v1.5.2...HEAD
+[1.5.2]: https://github.com/GeoStat-Framework/gstools/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/GeoStat-Framework/gstools/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/GeoStat-Framework/gstools/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/GeoStat-Framework/gstools/compare/v1.4.0...v1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 [project.optional-dependencies]
 doc = [
     "m2r2>=0.2.8",
-    "matplotlib>=3",
+    "matplotlib>=3.7",
     "meshzoo>=0.7",
     "numpydoc>=1.1",
     "pykrige>=1.5,<2",
@@ -68,7 +68,7 @@ doc = [
     "sphinxcontrib-youtube>=1.1",
 ]
 plotting = [
-    "matplotlib>=3",
+    "matplotlib>=3.7",
     "pyvista>=0.40",
 ]
 rust = ["gstools_core>=0.2.0,<1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,5 +166,3 @@ skip = ["cp36-*", "cp37-*", "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_*
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"
-# Skip trying to test arm64 builds on Intel Macs
-test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"

--- a/src/gstools/covmodel/fit.py
+++ b/src/gstools/covmodel/fit.py
@@ -214,6 +214,7 @@ def fit_variogram(
 def _pre_para(model, para_select, sill, anis):
     """Preprocess selected parameters."""
     var_last = False
+    var_tmp = 0.0  # init value
     for par in para_select:
         if par not in model.arg_bounds:
             raise ValueError(f"fit: unknown parameter in selection: {par}")
@@ -464,6 +465,7 @@ def _post_fitting(model, para, popt, anis, is_dir_vario):
     fit_para = {}
     para_skip = 0
     opt_skip = 0
+    var_tmp = 0.0  # init value
     for par in DEFAULT_PARA:
         if para[par]:
             if par == "var":  # set variance last

--- a/src/gstools/field/plot.py
+++ b/src/gstools/field/plot.py
@@ -232,13 +232,6 @@ def plot_nd(
         )
         rax.set_title("  Plane", loc="left")
         radio = RadioButtons(rax, plane_names, activecolor="grey")
-        # make radio buttons circular
-        rpos = rax.get_position().get_points()
-        fh, fw = fig.get_figheight(), fig.get_figwidth()
-        rscale = (rpos[:, 1].ptp() / rpos[:, 0].ptp()) * (fh / fw)
-        for circ in radio.circles:
-            circ.set_radius(0.06)
-            circ.height /= rscale
     elif mesh_type == "unstructured" and convex_hull:
         # show convex hull in 2D
         hull = ConvexHull(pos.T)

--- a/src/gstools/field/plot.py
+++ b/src/gstools/field/plot.py
@@ -291,6 +291,7 @@ def plot_nd(
             s.vline.set_data(2 * [s.valinit], [-0.1, 1.1])
             s.reset()
         im.set_extent(ax_extents[p])
+        asp = 1.0  # init value
         if aspect == "quad":
             asp = ax_rngs[planes[p][0]] / ax_rngs[planes[p][1]]
         if aspect is not None:

--- a/src/gstools/field/plot.py
+++ b/src/gstools/field/plot.py
@@ -10,7 +10,7 @@ The following classes and functions are provided
    plot_vec_field
 """
 
-# pylint: disable=C0103, W0613, E1101
+# pylint: disable=C0103, W0613, E1101, E0606
 import numpy as np
 from scipy import interpolate as inter
 from scipy.spatial import ConvexHull

--- a/src/gstools/krige/base.py
+++ b/src/gstools/krige/base.py
@@ -337,6 +337,7 @@ class Krige(Field):
         # determine the chunk size
         chunk_size = len(pos[0]) if chunk_slice[1] is None else chunk_slice[1]
         chunk_size -= chunk_slice[0]
+        chunk_pos = None  # init value
         res = np.empty((self.krige_size, chunk_size), dtype=np.double)
         if only_mean:
             # set points to limit of the covariance to only get the mean

--- a/src/gstools/transform/field.py
+++ b/src/gstools/transform/field.py
@@ -262,8 +262,7 @@ def binary(
     """
     if not process and divide is None:
         _check_for_default_normal(fld)
-    if divide is None:
-        mean = 0.0 if process and not keep_mean else fld.mean
+    mean = 0.0 if process and not keep_mean else fld.mean
     divide = mean if divide is None else divide
     upper = mean + np.sqrt(fld.model.sill) if upper is None else upper
     lower = mean - np.sqrt(fld.model.sill) if lower is None else lower


### PR DESCRIPTION
Finalize GSTools for v1.5.2

last minute fixes:
- remove universal2 wheels for macos (we already have intel and arm64 wheels and numpy also doesn't provide separate universal2 wheels)
- specify macos image versions in CI
- increase minimal matplotlib version to 3.7 (fixes radio button hack)
- minor pylint fixes for used-before-assignment issues