### PR TITLE
vario_estimate: recalc pnt_cnt when applying a mask

### DIFF
--- a/src/gstools/variogram/variogram.py
+++ b/src/gstools/variogram/variogram.py
@@ -398,6 +398,7 @@ def vario_estimate(
         field.fill_value = np.nan  # use no-data val. for remaining masked vals
         field = field[:, select].filled()  # convert to ndarray
         select = mask = None  # free space
+        pnt_cnt = len(pos[0])  # pnt cnt reduced now
     # set no_data values
     if not np.isnan(no_data):
         field[np.isclose(field, float(no_data))] = np.nan


### PR DESCRIPTION
fixes #377 

`pnt_cnt` was not recalculated in `vario_estimate` when a mask was applied. Together with a given sample size, this resulted in an `IndexError` most of the times.