### PR TITLE
Drop Python 3.8, depend on scipy>=1.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,20 +65,15 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
         # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
         ver:
-          - { py: "3.8", np: "==1.20.0", sp: "==1.5.4" }
-          - { py: "3.9", np: "==1.20.0", sp: "==1.5.4" }
+          - { py: "3.9", np: "==1.20.0", sp: "==1.6.3" }
           - { py: "3.10", np: "==1.21.6", sp: "==1.7.2" }
           - { py: "3.11", np: "==1.23.2", sp: "==1.9.2" }
           - { py: "3.12", np: "==1.26.2", sp: "==1.11.2" }
           - { py: "3.13", np: "==2.1.0", sp: "==1.14.1" }
           - { py: "3.13", np: ">=2.1.0", sp: ">=1.14.1" }
         exclude:
-          - os: ubuntu-24.04-arm
-            ver: { py: "3.8", np: "==1.20.0", sp: "==1.5.4" }
           - os: macos-14
-            ver: { py: "3.8", np: "==1.20.0", sp: "==1.5.4" }
-          - os: macos-14
-            ver: { py: "3.9", np: "==1.20.0", sp: "==1.5.4" }
+            ver: { py: "3.9", np: "==1.20.0", sp: "==1.6.3" }
           - os: macos-14
             ver: { py: "3.10", np: "==1.21.6", sp: "==1.7.2" }
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 build-backend = "hatchling.build"
 
 [project]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 name = "gstools"
 description = "GSTools: A geostatistical toolbox."
 authors = [
@@ -31,7 +31,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -51,7 +50,7 @@ dependencies = [
     "meshio>=5.1.0",
     "numpy>=1.20.0",
     "pyevtk>=1.1.1",
-    "scipy>=1.1.0",
+    "scipy>=1.6.0",
 ]
 
 [project.optional-dependencies]
@@ -59,7 +58,7 @@ doc = [
     "myst_parser",
     "matplotlib>=3.7",
     "meshzoo>=0.7",
-    "numpydoc>=1.1",
+    "numpydoc>=1.2",
     "pykrige>=1.5,<2",
     "pyvista>=0.40",
     "sphinx>=7",
@@ -71,7 +70,7 @@ plotting = [
     "matplotlib>=3.7",
     "pyvista>=0.40",
 ]
-rust = ["gstools_core>=1.0.0"]
+rust = ["gstools_core>=1.0.0; python_version >= '3.10'"]
 test = ["pytest-cov>=3"]
 lint = [
     "black>=24",
@@ -115,7 +114,6 @@ line_length = 79
 [tool.black]
 line-length = 79
 target-version = [
-    "py38",
     "py39",
     "py310",
     "py311",


### PR DESCRIPTION
Python 3.8 reached it's end-of-life in 2024-10-07 ([PEP 569](https://peps.python.org/pep-0569/)), so should be dropped.

Change SciPy dependency to >=[1.6.0](https://pypi.org/project/scipy/1.6.0/) to overlap with Python 3.9. Similar with NumPyDoc. All other deps have not changed, as they appear to overlap with Python 3.9.

gstools-core only supports Python>=3.10, so add conditional so that (e.g.) `uv sync --all-extras` succeeds.