### PR TITLE
Update gstools-core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ doc = [
     "sphinxcontrib-youtube>=1.1",
 ]
 plotting = ["matplotlib>=3.7", "pyvista>=0.40"]
-rust = ["gstools_core>=1.0.0"]
+rust = ["gstools_core>=1.3.0"]
 test = ["pytest-cov>=3"]
 lint = ["ruff"]
 


### PR DESCRIPTION
The old versions do not support Py3.14