### PR TITLE
fix(covmodel): ensure positive percentile_scale using bounded brentq

### DIFF
--- a/src/gstools/covmodel/tools.py
+++ b/src/gstools/covmodel/tools.py
@@ -27,7 +27,7 @@ import warnings
 import numpy as np
 from hankel import SymmetricFourierTransform as SFT
 from scipy import special as sps
-from scipy.optimize import root
+from scipy.optimize import root_scalar
 
 from gstools.tools.geometric import no_of_angles, set_angles, set_anis
 from gstools.tools.misc import list_format
@@ -439,8 +439,12 @@ def percentile_scale(model, per=0.9):
     def curve(x):
         return 1.0 - model.correlation(x) - per
 
-    # take 'per * len_rescaled' as initial guess
-    return root(curve, per * model.len_rescaled)["x"][0]
+    # upper bound for bracket where curve(b) > 0
+    b = float(max(model.len_rescaled, 1e-5))
+    while curve(b) <= 0:
+        b *= 2.0
+
+    return root_scalar(curve, bracket=[0.0, b], method="brentq").root
 
 
 def set_arg_bounds(model, check_args=True, **kwargs):

--- a/tests/test_covmodel.py
+++ b/tests/test_covmodel.py
@@ -351,6 +351,12 @@ class TestCovModel(unittest.TestCase):
         self.assertRaises(ValueError, Gau_fix, latlon=True)
         # check inputs
         self.assertRaises(ValueError, model_std.percentile_scale, per=-1.0)
+        # check positive percentile scale for SuperSpherical across nu values
+        for nu in (0.5, 1.0, 2.0, 5.0, 10.0):
+            m = SuperSpherical(dim=2, nu=nu, len_scale=10.0)
+            ps = m.percentile_scale(0.9)
+            self.assertGreater(ps, 0.0)
+            self.assertAlmostEqual(m.correlation(ps), 0.1, places=5)
         self.assertRaises(ValueError, Gaussian, anis=-1.0)
         self.assertRaises(ValueError, Gaussian, len_scale=[1, -1])
         self.assertRaises(ValueError, check_arg_in_bounds, model_std, "wrong")


### PR DESCRIPTION

# `fix(covmodel): ensure positive percentile_scale using bounded brentq`

## Problem
`CovModel.percentile_scale(per)` returned negative distance scales (e.g. `-6.215` for `SuperSpherical` with `nu >= 2`). A percentile scale represents physical distance and must be positive ($r \ge 0$).

## Cause
- Correlation functions are even $\rho(-r) = \rho(r)$, making $1 - \rho(r) - \text{per} = 0$ symmetric with roots at $+r_0$ and $-r_0$.
- `percentile_scale` used unconstrained `scipy.optimize.root`.
- For models with sharp drop-offs (`SuperSpherical` with $\nu \ge 2$), flat gradients near $x_0 = 0.9 \cdot \ell$ caused the solver to overshoot across zero and converge onto the mirror root $-r_0$.

## Fix
Replace `scipy.optimize.root` with `scipy.optimize.root_scalar(method="brentq")` bounded on $[0, b]$:
- Constrains the search to $r \ge 0$.
- Dynamically expands upper bound $b$ until $\text{curve}(b) > 0$.
- Guarantees convergence without derivative sensitivity.

## Verification
```python
import gstools as gs
for nu in (0.5, 1.0, 2.0, 5.0):
    m = gs.SuperSpherical(dim=2, nu=nu, len_scale=10.0)
    print(nu, m.percentile_scale(0.9))
```
- **Before**: `nu=2.0 -> -6.215`, `nu=5.0 -> -4.575`
- **After**: `nu=2.0 -> +6.215`, `nu=5.0 -> +4.575`

Test suite: `pytest tests/test_covmodel.py` (7/7 passed).